### PR TITLE
apply 0 return mask

### DIFF
--- a/vectorbt/portfolio/trades.py
+++ b/vectorbt/portfolio/trades.py
@@ -389,6 +389,9 @@ class Trades(Records):
 
         self_col = self.select_series(column=column, group_by=False)
 
+        self_col = self_col.filter_by_mask(self_col.values['return'] != 0)
+
+
         if closed_profit_trace_kwargs is None:
             closed_profit_trace_kwargs = {}
         if closed_loss_trace_kwargs is None:
@@ -422,20 +425,13 @@ class Trades(Records):
             profit_mask = pnl > 0
             loss_mask = pnl < 0
 
-            _id = _id[~neutral_mask]
-            exit_idx = exit_idx[~neutral_mask]  # needed for rel_rescale
-            pnl = pnl[~neutral_mask]
-            returns = returns[~neutral_mask]
             marker_size = min_rel_rescale(np.abs(returns), marker_size_range)
             opacity = max_rel_rescale(np.abs(returns), opacity_range)
 
             open_mask = status == TradeStatus.Open
             closed_profit_mask = (~open_mask) & profit_mask
             closed_loss_mask = (~open_mask) & loss_mask
-
             open_mask &= ~neutral_mask
-            closed_profit_mask = closed_profit_mask[~neutral_mask]
-            closed_loss_mask = closed_loss_mask[~neutral_mask]
 
             if np.any(closed_profit_mask):
                 # Plot Profit markers

--- a/vectorbt/portfolio/trades.py
+++ b/vectorbt/portfolio/trades.py
@@ -422,6 +422,7 @@ class Trades(Records):
             profit_mask = pnl > 0
             loss_mask = pnl < 0
 
+            _id = _id[~neutral_mask]
             exit_idx = exit_idx[~neutral_mask]  # needed for rel_rescale
             pnl = pnl[~neutral_mask]
             returns = returns[~neutral_mask]
@@ -431,7 +432,10 @@ class Trades(Records):
             open_mask = status == TradeStatus.Open
             closed_profit_mask = (~open_mask) & profit_mask
             closed_loss_mask = (~open_mask) & loss_mask
+
             open_mask &= ~neutral_mask
+            closed_profit_mask = closed_profit_mask[~neutral_mask]
+            closed_loss_mask = closed_loss_mask[~neutral_mask]
 
             if np.any(closed_profit_mask):
                 # Plot Profit markers

--- a/vectorbt/portfolio/trades.py
+++ b/vectorbt/portfolio/trades.py
@@ -389,8 +389,6 @@ class Trades(Records):
 
         self_col = self.select_series(column=column, group_by=False)
 
-        self_col = self_col.filter_by_mask(self_col.values['return'] != 0)
-
 
         if closed_profit_trace_kwargs is None:
             closed_profit_trace_kwargs = {}

--- a/vectorbt/utils/array.py
+++ b/vectorbt/utils/array.py
@@ -86,7 +86,11 @@ def min_rel_rescale(a, to_range):
     if a_max - a_min == 0:
         return np.full(a.shape, to_range[0])
     from_range = (a_min, a_max)
-    from_range_ratio = a_max / a_min
+
+    from_range_ratio = np.inf
+    if a_min != 0:
+        from_range_ratio = a_max / a_min
+
     to_range_ratio = to_range[1] / to_range[0]
     if from_range_ratio < to_range_ratio:
         to_range = (to_range[0], to_range[0] * from_range_ratio)
@@ -100,7 +104,11 @@ def max_rel_rescale(a, to_range):
     if a_max - a_min == 0:
         return np.full(a.shape, to_range[1])
     from_range = (a_min, a_max)
-    from_range_ratio = a_max / a_min
+
+    from_range_ratio = np.inf
+    if a_min != 0:
+        from_range_ratio = a_max / a_min
+
     to_range_ratio = to_range[1] / to_range[0]
     if from_range_ratio < to_range_ratio:
         to_range = (to_range[1] / from_range_ratio, to_range[1])


### PR DESCRIPTION
If you have a 0 return trade, this chokes but not sure this is the best way to fix it.  

```
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-65-53da79afee4b> in <module>
----> 1 portfolio.plot().show()

~/vectorbt/vectorbt/portfolio/base.py in plot(self, column, subplots, group_by, show_titles, hide_id_labels, group_id_labels, hline_shape_kwargs, make_subplots_kwargs, **kwargs)
   2354                     self_col.trades(**method_kwargs).plot_pnl(
   2355                         **trade_pnl_kwargs,
-> 2356                         row=row, col=col, xref=xref, yref=yref, fig=fig)
   2357                     fig.layout[xaxis]['title'] = 'Date'
   2358                     fig.layout[yaxis]['title'] = 'PnL'

~/vectorbt/vectorbt/portfolio/trades.py in plot_pnl(self, column, marker_size_range, opacity_range, closed_profit_trace_kwargs, closed_loss_trace_kwargs, open_trace_kwargs, hline_shape_kwargs, row, col, xref, yref, fig, **layout_kwargs)
    441                 # Plot Profit markers
    442                 profit_scatter = go.Scatter(
--> 443                     x=self_col.wrapper.index[exit_idx[closed_profit_mask]],
    444                     y=pnl[closed_profit_mask],
    445                     mode='markers',

IndexError: boolean index did not match indexed array along dimension 0; dimension is 367 but corresponding boolean dimension is 368
```