### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,8 +169,8 @@ pf.total_profit()
 ```python
 fast_ma = vbt.MA.run(price, 10)
 slow_ma = vbt.MA.run(price, 50)
-entries = fast_ma.ma_crossed_above(slow_ma)
-exits = fast_ma.ma_crossed_below(slow_ma)
+entries = fast_ma.ma_above(slow_ma)
+exits = fast_ma.ma_below(slow_ma)
 
 pf = vbt.Portfolio.from_signals(price, entries, exits, init_cash=100)
 pf.total_profit()


### PR DESCRIPTION
- I believe the ma_crossed_above is deprecated. 
- added ma_above instead of ma_crossed_above as same for below.