### PR TITLE
Adds AlpacaData Custom Data Source

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ and comes with Jupyter environment, vectorbt, and other scientific packages inst
 
 ### Data
 
-- [x] **Data acquisition**: Supports various data providers, such as **[Yahoo Finance](https://github.com/ranaroussi/yfinance)**, **[Binance](https://github.com/sammchardy/python-binance)**, and **[CCXT](https://github.com/ccxt/ccxt)**. Can merge multiple symbols with different index, as well as update them. **[>>](https://vectorbt.dev/docs/data/custom.html)**
+- [x] **Data acquisition**: Supports various data providers, such as **[Yahoo Finance](https://github.com/ranaroussi/yfinance)**, **[Binance](https://github.com/sammchardy/python-binance)** **[CCXT](https://github.com/ccxt/ccxt)** and **[Alpaca](https://github.com/alpacahq/alpaca-trade-api-python)**. Can merge multiple symbols with different index, as well as update them. **[>>](https://vectorbt.dev/docs/data/custom.html)**
 - [x] **Data generation**: Supports various (random) data generators, such as **[GBM](https://en.wikipedia.org/wiki/Geometric_Brownian_motion)**. **[>>](https://vectorbt.dev/docs/data/custom.html)**
 - [x] **Scheduled data updates**: Can periodically update any previously downloaded data. **[>>](https://vectorbt.dev/docs/data/updater.html)**
 - [x] **Data preparation**: Transformation, rescaling, and normalization of data. Custom splitters for cross-validation. Supports **[Scikit-Learn](https://github.com/scikit-learn/scikit-learn)** splitters, such as for K-Folds cross-validation. **[>>](https://vectorbt.dev/docs/generic/accessors.html)**

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ and comes with Jupyter environment, vectorbt, and other scientific packages inst
 
 ### Data
 
-- [x] **Data acquisition**: Supports various data providers, such as **[Yahoo Finance](https://github.com/ranaroussi/yfinance)**, **[Binance](https://github.com/sammchardy/python-binance)** **[CCXT](https://github.com/ccxt/ccxt)** and **[Alpaca](https://github.com/alpacahq/alpaca-trade-api-python)**. Can merge multiple symbols with different index, as well as update them. **[>>](https://vectorbt.dev/docs/data/custom.html)**
+- [x] **Data acquisition**: Supports various data providers, such as **[Yahoo Finance](https://github.com/ranaroussi/yfinance)**, **[Binance](https://github.com/sammchardy/python-binance)**, **[CCXT](https://github.com/ccxt/ccxt)** and **[Alpaca](https://github.com/alpacahq/alpaca-trade-api-python)**. Can merge multiple symbols with different index, as well as update them. **[>>](https://vectorbt.dev/docs/data/custom.html)**
 - [x] **Data generation**: Supports various (random) data generators, such as **[GBM](https://en.wikipedia.org/wiki/Geometric_Brownian_motion)**. **[>>](https://vectorbt.dev/docs/data/custom.html)**
 - [x] **Scheduled data updates**: Can periodically update any previously downloaded data. **[>>](https://vectorbt.dev/docs/data/updater.html)**
 - [x] **Data preparation**: Transformation, rescaling, and normalization of data. Custom splitters for cross-validation. Supports **[Scikit-Learn](https://github.com/scikit-learn/scikit-learn)** splitters, such as for K-Folds cross-validation. **[>>](https://vectorbt.dev/docs/generic/accessors.html)**

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
             'yfinance>=0.1.63',
             'python-binance',
             'ccxt',
+            'alpaca-trade-api==1.4.3',
             'ray>=1.4.1',
             'ta',
             'pandas_ta',

--- a/vectorbt/_settings.py
+++ b/vectorbt/_settings.py
@@ -163,6 +163,12 @@ settings = SettingsConfig(
             tz_convert=get_utc_tz(),
             missing_index='nan',
             missing_columns='raise',
+            alpaca=Config(
+                dict(
+                    key_id=None,
+                    secret_key=None
+                )
+            ),
             binance=Config(  # flex
                 dict(
                     api_key=None,

--- a/vectorbt/data/__init__.py
+++ b/vectorbt/data/__init__.py
@@ -4,7 +4,7 @@
 """Modules for working with data sources."""
 
 from vectorbt.data.base import symbol_dict, Data
-from vectorbt.data.custom import SyntheticData, GBMData, YFData, BinanceData, CCXTData
+from vectorbt.data.custom import SyntheticData, GBMData, YFData, BinanceData, CCXTData, AlpacaData
 from vectorbt.data.updater import DataUpdater
 
 __all__ = [
@@ -15,7 +15,8 @@ __all__ = [
     'GBMData',
     'YFData',
     'BinanceData',
-    'CCXTData'
+    'CCXTData',
+    'AlpacaData'
 ]
 
 __pdoc__ = {k: False for k in __all__}

--- a/vectorbt/data/custom.py
+++ b/vectorbt/data/custom.py
@@ -759,8 +759,9 @@ class CCXTData(Data):
         return self.download_symbol(symbol, **kwargs)
 
 class AlpacaData(Data):
-    """`Data` for data coming from `alpaca-trade-api`.
-
+    """`Data` for data coming from `alpaca-trade-api`. 
+    Sign up for Alpaca API keys here: https://app.alpaca.markets/signup
+    
     ## Example
 
     Fetch the 1-minute data of the last 2 hours, wait 1 minute, and update:

--- a/vectorbt/data/custom.py
+++ b/vectorbt/data/custom.py
@@ -759,7 +759,7 @@ class CCXTData(Data):
         return self.download_symbol(symbol, **kwargs)
 
 class AlpacaData(Data):
-    """`Data` for data coming from `python-binance`.
+    """`Data` for data coming from `alpaca-trade-api`.
 
     ## Example
 


### PR DESCRIPTION
Integrates Alpaca's Historical Data API for equities and crypto into vectorbt.
Alpaca provides 5+ years of historical data at up to 1 minute resolution. 

You'll need an API key to access AlpacaData.
You can provide the API key in the settings
```
vectorbt.settings.data['alpaca']['key_id'] = 'Your Alpaca API Key'
vectorbt.settings.data['alpaca']['secret_key'] = 'You Alpaca Secret Key'
```

All tests are passing and README has also been updated to reflect the changes.