### PR TITLE
Update _settings.py for Seaborn

### DIFF
--- a/vectorbt/_settings.py
+++ b/vectorbt/_settings.py
@@ -239,16 +239,16 @@ settings = SettingsConfig(
                 seaborn=dict(
                     color_schema=Config(  # flex
                         dict(
-                            blue="rgb(76,114,176)",
-                            orange="rgb(221,132,82)",
-                            green="rgb(129,114,179)",
-                            red="rgb(85,168,104)",
-                            purple="rgb(218,139,195)",
-                            brown="rgb(204,185,116)",
-                            pink="rgb(140,140,140)",
-                            gray="rgb(100,181,205)",
-                            yellow="rgb(147,120,96)",
-                            cyan="rgb(196,78,82)"
+                            blue="#1f77b4",
+                            orange="#ff7f0e",
+                            green="#2ca02c",
+                            red="#dc3912",
+                            purple="#9467bd",
+                            brown="#8c564b",
+                            pink="#e377c2",
+                            gray="#7f7f7f",
+                            yellow="#bcbd22",
+                            cyan="#17becf"
                         )
                     ),
                     template=Config(json.loads(pkgutil.get_data(__name__, "templates/seaborn.json"))),  # flex


### PR DESCRIPTION
Hi!

## What?
I changed Seaborn theme colors format to HEX format (as in other themes) from RGB format.

## Why?
While using Seaborn, plotting fails for many default graphs, mainly from portfolio.plot().

## Comment
Is there any reason why color settings for Seaborn theme are in RGB instead of HEX?
In PR I just changed the colors to same format as in other themes, if there is a reason - there may be a better fix, but this works in my environment after the change, fails with default.

Error:
```
  File "D:\Google Drive Sync\Rzeczy\Projekty_PY\Boty\CyberOasisProjectReborn\gieldy\vectorbt\main.py", line 67, in backtest_keltner
    fig = pf.plot(subplots=[
  File "D:\Google Drive Sync\Rzeczy\Projekty_PY\.venvs\Crypto-Venv-3-10-0\lib\site-packages\vectorbt\generic\plots_builder.py", line 604, in plots
    raise e
  File "D:\Google Drive Sync\Rzeczy\Projekty_PY\.venvs\Crypto-Venv-3-10-0\lib\site-packages\vectorbt\generic\plots_builder.py", line 589, in plots
    plot_func(**final_kwargs)
  File "D:\Google Drive Sync\Rzeczy\Projekty_PY\.venvs\Crypto-Venv-3-10-0\lib\site-packages\vectorbt\portfolio\base.py", line 4940, in plot_assets
    fillcolor=adjust_opacity(plotting_cfg['color_schema']['brown'], 0.3)
  File "D:\Google Drive Sync\Rzeczy\Projekty_PY\.venvs\Crypto-Venv-3-10-0\lib\site-packages\vectorbt\utils\colors.py", line 27, in adjust_opacity
    rgb = mc.to_rgb(color)
  File "D:\Google Drive Sync\Rzeczy\Projekty_PY\.venvs\Crypto-Venv-3-10-0\lib\site-packages\matplotlib\colors.py", line 496, in to_rgb
    return to_rgba(c)[:3]
  File "D:\Google Drive Sync\Rzeczy\Projekty_PY\.venvs\Crypto-Venv-3-10-0\lib\site-packages\matplotlib\colors.py", line 299, in to_rgba
    rgba = _to_rgba_no_colorcycle(c, alpha)
  File "D:\Google Drive Sync\Rzeczy\Projekty_PY\.venvs\Crypto-Venv-3-10-0\lib\site-packages\matplotlib\colors.py", line 374, in _to_rgba_no_colorcycle
    raise ValueError(f"Invalid RGBA argument: {orig_c!r}")
ValueError: Invalid RGBA argument: 'rgb(204,185,116)'

Process finished with exit code 1

```

On:

```
pf.plot(subplots=[
            "drawdowns"])
```

Because of:
```
kwargs = merge_dicts(dict(
            trace_kwargs=dict(
                line=dict(
                    color=plotting_cfg['color_schema']['brown']
                ),
                name='Assets'
            ),
            pos_trace_kwargs=dict(
                fillcolor=adjust_opacity(plotting_cfg['color_schema']['brown'], 0.3)
            ),
            neg_trace_kwargs=dict(
                fillcolor=adjust_opacity(plotting_cfg['color_schema']['orange'], 0.3)
            ),
            other_trace_kwargs='hidden'
```

Where adjust_opacity takes color in HEX format and fails on this RGB format from Seaborn:

```
def adjust_opacity(color: tp.Any, opacity: float) -> str:
    """Adjust opacity of color."""
    import matplotlib.colors as mc
    print(color)
    rgb = mc.to_rgb(color)
    print(rgb)
    return 'rgba(%d,%d,%d,%.4f)' % (int(rgb[0] * 255), int(rgb[1] * 255), int(rgb[2] * 255), opacity)
```