### PR TITLE
Make talib support multi timescale. 

### DIFF
--- a/vectorbt/indicators/__init__.py
+++ b/vectorbt/indicators/__init__.py
@@ -24,6 +24,9 @@ def talib(*args, **kwargs) -> tp.Type[IndicatorBase]:
     """Shortcut for `vectorbt.indicators.factory.IndicatorFactory.from_talib`."""
     return IndicatorFactory.from_talib(*args, **kwargs)
 
+def mtalib(*args, **kwargs) -> tp.Type[IndicatorBase]:
+    """Shortcut for `vectorbt.indicators.factory.IndicatorFactory.from_talib`."""
+    return IndicatorFactory.from_mtalib(*args, **kwargs)
 
 def pandas_ta(*args, **kwargs) -> tp.Type[IndicatorBase]:
     """Shortcut for `vectorbt.indicators.factory.IndicatorFactory.from_pandas_ta`."""
@@ -38,6 +41,7 @@ def ta(*args, **kwargs) -> tp.Type[IndicatorBase]:
 __all__ = [
     'IndicatorFactory',
     'talib',
+    'mtalib',
     'pandas_ta',
     'ta',
     'MA',
@@ -50,6 +54,7 @@ __all__ = [
     'OBV'
 ]
 __whitelist__ = [
+    'mtalib',
     'talib',
     'pandas_ta',
     'ta'


### PR DESCRIPTION
For example, I have 1 minute scale tick data, and I'd like add 5 minute/ 15 minute feature upon .

I wrote a function 
```
def apply_over(func, arr, stride):
	n = len(arr)
	s = np.empty(n).reshape(-1, stride)

	for i in range(stride):
		s[:,i] = func(arr[i::stride])

	return s.reshape(n,)
```

This generate 5 minute SMA features for each 1 minute tick .
```
arr = np.arange(n).astype(float)
sma_5_5 = apply_over(lambda a: talib.SMA(a, 5) , arr, 5)
```

you can think `arr = np.arange(1000).astype(float)` as a stock close price at minute level . 
It is a 1000 time tick collection.  

On every tick , I need calculate `sma5` on 
- 1 minute scale  (simply `talib.SMA(arr, 5)`  )
- 5 minute scale  (`apply_over(lambda a: talib.SMA(a, 5) , arr, 5)`  )
- 15 minute scale  (`apply_over(lambda a: talib.SMA(a, 5) , arr, 15)`  )

For example:
A series `...,500, 501, 502, 503, 504 , 505,....` 

At 505, 
- 1 minute scale  =  SMA([ 501, 502, 503, 504 , 505])
- 5 minute scale  =  SMA([ 485, 490, 495, 500 , 505])


Using `pandas resmple(freq='5min').first()` would make gaps , shrink `arr` length from `1000` to `200` . You need do it 5 times with each shift [0,1,2,3,4] and apply `SMA` to make sure every tick have 5 minute feature,  , like what I do in `apply_over`

----

Because I really like vectorbt, so share this idea here.  

