### PR TITLE
In python-telegram-bot>=20.0 Unauthorized is replaced by Forbidden.

### DIFF
--- a/vectorbt/messaging/telegram.py
+++ b/vectorbt/messaging/telegram.py
@@ -268,7 +268,7 @@ class TelegramBot(Configured):
             self.chat_ids.append(new_id)
             # Resend to new chat id
             self.send(kind, new_id, *args, log_msg=log_msg, **kwargs)
-        except Unauthorized as e:
+        except Forbidden as e:
             logger.info(f"{chat_id} - Unauthorized to send the %s", kind)
 
     def send_to_all(self, kind: str, *args, **kwargs) -> None:

--- a/vectorbt/messaging/telegram.py
+++ b/vectorbt/messaging/telegram.py
@@ -7,7 +7,7 @@ import logging
 from functools import wraps
 
 from telegram import Update
-from telegram.error import Unauthorized, ChatMigrated
+from telegram.error import Forbidden, ChatMigrated
 from telegram.ext import (
     Handler,
     CallbackContext,


### PR DESCRIPTION
Source: [https://docs.python-telegram-bot.org/en/stable/telegram.error.html#telegram.error.Forbidden](https://docs.python-telegram-bot.org/en/stable/telegram.error.html#telegram.error.Forbidden)