### PR TITLE
Updated telegram error Unauthorized to Forbidden

### DIFF
--- a/vectorbt/messaging/telegram.py
+++ b/vectorbt/messaging/telegram.py
@@ -17,7 +17,7 @@ if __version_info__ >= (20, 0):
     raise RuntimeError(f"This implementation is not compatible with telegram version {TG_VER}")
 
 from telegram import Update
-from telegram.error import Unauthorized, ChatMigrated
+from telegram.error import Forbidden, ChatMigrated
 from telegram.ext import (
     Handler,
     CallbackContext,
@@ -278,7 +278,7 @@ class TelegramBot(Configured):
             self.chat_ids.append(new_id)
             # Resend to new chat id
             self.send(kind, new_id, *args, log_msg=log_msg, **kwargs)
-        except Unauthorized as e:
+        except Forbidden as e:
             logger.info(f"{chat_id} - Unauthorized to send the %s", kind)
 
     def send_to_all(self, kind: str, *args, **kwargs) -> None:


### PR DESCRIPTION
error renamed in python-telegram-bot version 20.0

https://docs.python-telegram-bot.org/en/v21.9/telegram.error.html