### PR TITLE
Add Agnostic Plotting Protocol

### DIFF
--- a/tests/test_plotting_backend.py
+++ b/tests/test_plotting_backend.py
@@ -1,0 +1,337 @@
+"""Tests for the plotting backend registry, `create_figure` factory,
+and the `default_backend` setting.
+
+These tests cover:
+- registry round-trip, validation, and override semantics
+- the `_plotly_factory` router (no-args -> make_figure;
+  explicit rows/cols or subplot-only kwargs -> make_subplots)
+- runtime mutation of `settings['plotting']['default_backend']`
+- public API exposure on `vbt.plotting.*` and top-level `vbt.*`
+"""
+
+import pytest
+
+import vectorbt as vbt
+from vectorbt.utils import figure as _figure_mod
+from vectorbt.utils.figure import (
+    Figure,
+    FigureWidget,
+    assert_plotly_only_kwargs,
+    assert_plotly_only_method,
+    create_figure,
+    get_backend,
+    list_backends,
+    make_figure,
+    make_subplots,
+    register_backend,
+    resolve_backend,
+    resolve_backend_for_fig,
+)
+from vectorbt.utils.plotting_protocol import Capability, FigureProtocol
+
+
+class _StubNonPlotlyFig:
+    """Minimal non-Plotly figure for testing resolution helpers."""
+    backend_name = 'stub'
+
+
+def _strip_uid(node):
+    if isinstance(node, dict):
+        return {k: _strip_uid(v) for k, v in node.items() if k != 'uid'}
+    if isinstance(node, list):
+        return [_strip_uid(x) for x in node]
+    return node
+
+
+@pytest.fixture(autouse=True)
+def _restore_backend_state():
+    saved_registry = dict(_figure_mod._BACKEND_REGISTRY)
+    saved_default = vbt.settings['plotting']['default_backend']
+    saved_use_widgets = vbt.settings['plotting']['use_widgets']
+    try:
+        yield
+    finally:
+        _figure_mod._BACKEND_REGISTRY.clear()
+        _figure_mod._BACKEND_REGISTRY.update(saved_registry)
+        vbt.settings['plotting']['default_backend'] = saved_default
+        vbt.settings['plotting']['use_widgets'] = saved_use_widgets
+
+
+class TestRegistryDefaults:
+    def test_default_backend_is_plotly(self):
+        assert 'plotly' in list_backends()
+        assert vbt.settings['plotting']['default_backend'] == 'plotly'
+
+
+class TestBackendNameAttribute:
+    def test_plotly_backend_name(self):
+        from vectorbt.utils.figure import PlotlyFigureProtocolMixin
+        assert PlotlyFigureProtocolMixin.backend_name == 'plotly'
+        fig = make_figure()
+        assert type(fig).backend_name == 'plotly'
+
+
+class TestResolveBackendForFig:
+    def test_none_defaults_to_plotly(self):
+        vbt.settings['plotting']['default_backend'] = 'plotly'
+        backend, is_plotly = resolve_backend_for_fig(None)
+        assert backend == 'plotly'
+        assert is_plotly is True
+
+    def test_none_defaults_to_custom(self):
+        vbt.settings['plotting']['default_backend'] = 'other'
+        backend, is_plotly = resolve_backend_for_fig(None)
+        assert backend == 'other'
+        assert is_plotly is False
+
+    def test_plotly_figure_instance(self):
+        fig = make_figure()
+        backend, is_plotly = resolve_backend_for_fig(fig)
+        assert backend == 'plotly'
+        assert is_plotly is True
+
+    def test_plotly_subplots_instance(self):
+        fig = make_subplots(rows=2, cols=1)
+        backend, is_plotly = resolve_backend_for_fig(fig)
+        assert backend == 'plotly'
+        assert is_plotly is True
+
+    def test_stub_figure_instance(self):
+        fig = _StubNonPlotlyFig()
+        backend, is_plotly = resolve_backend_for_fig(fig)
+        assert backend == 'stub'
+        assert is_plotly is False
+
+    def test_third_party_backend_uses_class_attribute(self):
+        class FakeFig:
+            backend_name = 'bokeh'
+        backend, is_plotly = resolve_backend_for_fig(FakeFig())
+        assert backend == 'bokeh'
+        assert is_plotly is False
+
+    def test_third_party_backend_falls_back_to_class_name(self):
+        class UnnamedFig:
+            pass
+        backend, is_plotly = resolve_backend_for_fig(UnnamedFig())
+        assert backend == 'UnnamedFig'
+        assert is_plotly is False
+
+
+class TestAssertPlotlyOnlyKwargs:
+    def test_noop_when_forcing_empty(self):
+        # No raise even on non-Plotly backend.
+        assert_plotly_only_kwargs(False, 'other', [], method_name='Foo.plot')
+
+    def test_noop_when_plotly(self):
+        # No raise even with forcing kwargs.
+        assert_plotly_only_kwargs(True, 'plotly', ['trace_kwargs'], method_name='Foo.plot')
+
+    def test_raises_on_non_plotly_with_forcing(self):
+        with pytest.raises(NotImplementedError) as exc:
+            assert_plotly_only_kwargs(
+                False, 'other', ['trace_kwargs', 'layout_kwargs'],
+                method_name='GenericAccessor.plot',
+            )
+        msg = str(exc.value)
+        assert 'GenericAccessor.plot' in msg
+        assert "'other'" in msg
+        assert 'trace_kwargs' in msg
+        assert 'layout_kwargs' in msg
+        assert 'legacy Plotly-specific escape hatches' in msg
+
+    def test_raises_mentions_third_party_backend_name(self):
+        with pytest.raises(NotImplementedError) as exc:
+            assert_plotly_only_kwargs(
+                False, 'bokeh', ['trace_kwargs'],
+                method_name='X.plot',
+            )
+        assert "'bokeh'" in str(exc.value)
+
+
+class TestAssertPlotlyOnlyMethod:
+    def test_noop_when_plotly(self):
+        assert_plotly_only_method(
+            True, 'plotly',
+            method_name='Foo.bar', reason='anything',
+        )
+
+    def test_raises_on_non_plotly(self):
+        with pytest.raises(NotImplementedError) as exc:
+            assert_plotly_only_method(
+                False, 'other',
+                method_name='GenericSRAccessor.plot_against',
+                reason='its fill-between-lines semantics have no portable equivalent.',
+            )
+        msg = str(exc.value)
+        assert 'permanently Plotly-only' in msg
+        assert 'plot_against' in msg
+        assert 'fill-between-lines' in msg
+        assert "'other'" in msg
+
+
+class TestCreateFigureRouting:
+    @pytest.mark.parametrize('use_widgets', [True, False])
+    def test_create_figure_no_args_matches_make_figure(self, use_widgets):
+        vbt.settings['plotting']['use_widgets'] = use_widgets
+        a = create_figure()
+        b = make_figure()
+        expected_cls = FigureWidget if use_widgets else Figure
+        assert isinstance(a, expected_cls)
+        assert isinstance(b, expected_cls)
+        if not use_widgets:
+            assert not isinstance(a, FigureWidget)
+            assert not isinstance(b, FigureWidget)
+        assert _strip_uid(a.to_plotly_json()) == _strip_uid(b.to_plotly_json())
+
+    def test_create_figure_rows_1_cols_1_routes_to_subplots(self):
+        fig = create_figure(rows=1, cols=1)
+        assert 'xaxis' in fig.layout
+        assert 'yaxis' in fig.layout
+        assert fig.get_subplot(1, 1) is not None
+        ref = make_subplots(rows=1, cols=1)
+        assert _strip_uid(fig.to_plotly_json()) == _strip_uid(ref.to_plotly_json())
+
+    def test_create_figure_rows_cols_matches_make_subplots(self):
+        fig = create_figure(rows=2, cols=1, shared_xaxes=True)
+        ref = make_subplots(rows=2, cols=1, shared_xaxes=True)
+        assert _strip_uid(fig.to_plotly_json()) == _strip_uid(ref.to_plotly_json())
+
+    def test_create_figure_specs_routes_to_make_subplots(self):
+        fig = create_figure(specs=[[{'secondary_y': True}]])
+        assert 'yaxis2' in fig.layout
+
+    def test_create_figure_rejects_positional_args(self):
+        with pytest.raises(TypeError):
+            create_figure(object())  # type: ignore[misc]
+
+
+class TestRegistryAPI:
+    def test_register_backend_roundtrip(self):
+        sentinel = object()
+
+        def _dummy(*, rows, cols, **kw):
+            return sentinel
+
+        register_backend('dummy', _dummy)
+        assert 'dummy' in list_backends()
+        assert create_figure(backend='dummy') is sentinel
+
+    def test_register_backend_duplicate_raises(self):
+        with pytest.raises(ValueError, match="already registered"):
+            register_backend('plotly', lambda **kw: None)
+
+    def test_register_backend_override_allowed(self):
+        def replacement(**kw):
+            return 'replaced'
+        register_backend('plotly', replacement, override=True)
+        assert get_backend('plotly') is replacement
+
+    def test_unknown_backend_raises_keyerror(self):
+        with pytest.raises(KeyError, match="plotly"):
+            create_figure(backend='nope')
+
+    def test_settings_override_default_backend(self):
+        called = []
+
+        def _dummy(*, rows, cols, **kw):
+            called.append((rows, cols, kw))
+            return 'dummy-figure'
+
+        register_backend('dummy', _dummy)
+        vbt.settings['plotting']['default_backend'] = 'dummy'
+        result = create_figure()
+        assert result == 'dummy-figure'
+        assert called == [(None, None, {})]
+
+    def test_register_backend_validation(self):
+        with pytest.raises(ValueError):
+            register_backend('', lambda **kw: None)
+        with pytest.raises(TypeError):
+            register_backend('bad', 'not-callable')
+
+
+class TestPublicAPIExposure:
+    def test_create_figure_exposed_via_vbt_plotting(self):
+        assert vbt.plotting.create_figure is create_figure
+        assert vbt.plotting.register_backend is register_backend
+        assert vbt.plotting.get_backend is get_backend
+        assert vbt.plotting.list_backends is list_backends
+        assert vbt.plotting.FigureProtocol is FigureProtocol
+        assert vbt.plotting.Capability is Capability
+        fig = vbt.plotting.create_figure()
+        assert isinstance(fig, (Figure, FigureWidget))
+
+    def test_create_figure_exposed_at_top_level(self):
+        assert vbt.create_figure is create_figure
+        assert vbt.register_backend is register_backend
+        assert vbt.get_backend is get_backend
+        assert vbt.list_backends is list_backends
+        a = vbt.create_figure()
+        b = vbt.make_figure()
+        assert isinstance(a, (Figure, FigureWidget))
+        assert isinstance(b, (Figure, FigureWidget))
+        assert _strip_uid(a.to_plotly_json()) == _strip_uid(b.to_plotly_json())
+
+    def test_vbt_plotting_existing_classes_unaffected(self):
+        assert hasattr(vbt.plotting, 'Gauge')
+        assert hasattr(vbt.plotting, 'Scatter')
+        assert hasattr(vbt.plotting, 'Heatmap')
+        assert hasattr(vbt.plotting, 'Histogram')
+        assert hasattr(vbt.plotting, 'Bar')
+        assert hasattr(vbt.plotting, 'Box')
+        assert hasattr(vbt.plotting, 'Volume')
+
+
+class TestResolveBackend:
+    """Tests for the resolve_backend() helper."""
+
+    def test_both_none_uses_default_plotly(self):
+        vbt.settings['plotting']['default_backend'] = 'plotly'
+        backend, is_plotly = resolve_backend(None, None)
+        assert backend == 'plotly'
+        assert is_plotly is True
+
+    def test_both_none_uses_default_custom(self):
+        vbt.settings['plotting']['default_backend'] = 'other'
+        backend, is_plotly = resolve_backend(None, None)
+        assert backend == 'other'
+        assert is_plotly is False
+
+    def test_backend_override_alone(self):
+        backend, is_plotly = resolve_backend(None, 'other')
+        assert backend == 'other'
+        assert is_plotly is False
+
+    def test_backend_override_plotly(self):
+        vbt.settings['plotting']['default_backend'] = 'other'
+        backend, is_plotly = resolve_backend(None, 'plotly')
+        assert backend == 'plotly'
+        assert is_plotly is True
+
+    def test_fig_alone_plotly(self):
+        fig = make_figure()
+        backend, is_plotly = resolve_backend(fig, None)
+        assert backend == 'plotly'
+        assert is_plotly is True
+
+    def test_fig_alone_stub(self):
+        fig = _StubNonPlotlyFig()
+        backend, is_plotly = resolve_backend(fig, None)
+        assert backend == 'stub'
+        assert is_plotly is False
+
+    def test_fig_and_matching_backend(self):
+        fig = make_figure()
+        backend, is_plotly = resolve_backend(fig, 'plotly')
+        assert backend == 'plotly'
+        assert is_plotly is True
+
+    def test_fig_and_conflicting_backend_raises(self):
+        fig = make_figure()
+        with pytest.raises(ValueError, match="conflicts"):
+            resolve_backend(fig, 'other')
+
+    def test_stub_fig_and_conflicting_backend_raises(self):
+        fig = _StubNonPlotlyFig()
+        with pytest.raises(ValueError, match="conflicts"):
+            resolve_backend(fig, 'plotly')

--- a/tests/test_plotting_backend.py
+++ b/tests/test_plotting_backend.py
@@ -200,6 +200,35 @@ class TestCreateFigureRouting:
         fig = create_figure(specs=[[{'secondary_y': True}]])
         assert 'yaxis2' in fig.layout
 
+    def test_create_figure_rows_only_fills_cols_to_1(self):
+        """rows=2 without cols must route to make_subplots(rows=2, cols=1)."""
+        fig = create_figure(rows=2)
+        ref = make_subplots(rows=2, cols=1)
+        assert _strip_uid(fig.to_plotly_json()) == _strip_uid(ref.to_plotly_json())
+
+    def test_create_figure_cols_only_fills_rows_to_1(self):
+        """cols=2 without rows must route to make_subplots(rows=1, cols=2)."""
+        fig = create_figure(cols=2)
+        ref = make_subplots(rows=1, cols=2)
+        assert _strip_uid(fig.to_plotly_json()) == _strip_uid(ref.to_plotly_json())
+
+    def test_create_figure_figure_kwarg_routes_to_subplots(self):
+        """figure= is in _SUBPLOT_ONLY_KWARGS, so create_figure(figure=fig) must
+        route through make_subplots with Plotly's populate-existing semantics:
+        pre-existing traces and layout on the base figure are preserved."""
+        import plotly.graph_objects as go
+        base = make_figure()
+        base.add_trace(go.Scatter(x=[1, 2], y=[3, 4], name="existing"))
+        base.update_layout(title_text="preserved")
+        fig = create_figure(figure=base)
+        # Subplot metadata was injected.
+        assert fig.get_subplot(1, 1) is not None
+        # Pre-existing trace survived.
+        assert len(fig.data) == 1
+        assert fig.data[0].name == "existing"
+        # Pre-existing layout survived.
+        assert fig.layout.title.text == "preserved"
+
     def test_create_figure_rejects_positional_args(self):
         with pytest.raises(TypeError):
             create_figure(object())  # type: ignore[misc]
@@ -207,14 +236,29 @@ class TestCreateFigureRouting:
 
 class TestRegistryAPI:
     def test_register_backend_roundtrip(self):
+        called = []
         sentinel = object()
 
         def _dummy(*, rows, cols, **kw):
+            called.append((rows, cols, kw))
             return sentinel
 
         register_backend('dummy', _dummy)
         assert 'dummy' in list_backends()
         assert create_figure(backend='dummy') is sentinel
+        assert called == [(None, None, {})]
+
+    def test_register_backend_forwards_kwargs(self):
+        """create_figure must forward rows, cols, and extra kwargs to the factory."""
+        called = []
+
+        def _dummy(*, rows, cols, **kw):
+            called.append((rows, cols, kw))
+            return 'dummy-figure'
+
+        register_backend('dummy', _dummy)
+        create_figure(backend='dummy', rows=3, cols=2, shared_xaxes=True)
+        assert called == [(3, 2, {'shared_xaxes': True})]
 
     def test_register_backend_duplicate_raises(self):
         with pytest.raises(ValueError, match="already registered"):
@@ -227,8 +271,15 @@ class TestRegistryAPI:
         assert get_backend('plotly') is replacement
 
     def test_unknown_backend_raises_keyerror(self):
-        with pytest.raises(KeyError, match="plotly"):
+        with pytest.raises(KeyError, match="nope"):
             create_figure(backend='nope')
+
+    def test_unregistered_default_backend_raises_keyerror(self):
+        """When the default_backend setting points to an unknown name,
+        create_figure() without explicit backend= must raise KeyError."""
+        vbt.settings['plotting']['default_backend'] = 'nonexistent'
+        with pytest.raises(KeyError, match="nonexistent"):
+            create_figure()
 
     def test_settings_override_default_backend(self):
         called = []

--- a/tests/test_plotting_protocol.py
+++ b/tests/test_plotting_protocol.py
@@ -1,4 +1,4 @@
-"""Tests for the backend-agnostic figure protocol and its Plotly implementation.
+"""Tests for the renderer-agnostic figure protocol and its Plotly implementation.
 
 Each protocol method is asserted to produce output byte-identical (modulo
 auto-generated trace `uid`s on widgets) to the equivalent hand-written

--- a/tests/test_plotting_protocol.py
+++ b/tests/test_plotting_protocol.py
@@ -1,0 +1,811 @@
+"""Tests for the backend-agnostic figure protocol and its Plotly implementation.
+
+Each protocol method is asserted to produce output byte-identical (modulo
+auto-generated trace `uid`s on widgets) to the equivalent hand-written
+Plotly construction, for both `Figure` and `FigureWidget`, with and without
+subplot positioning via `row`/`col`.
+"""
+
+from datetime import datetime
+
+import pandas as pd
+import plotly.graph_objects as go
+import pytest
+from plotly.basedatatypes import BaseFigure
+
+from vectorbt.utils.figure import (
+    Figure,
+    FigureWidget,
+    get_domain,
+    make_figure,
+    make_subplots,
+)
+from vectorbt.utils.plotting_protocol import Capability, FigureProtocol
+
+
+# ############# Fixtures ############# #
+
+index_5 = pd.DatetimeIndex([datetime(2020, 1, d) for d in range(1, 6)])
+x_arr = list(index_5)
+y_arr = [1.0, 2.0, 3.0, 4.0, 5.0]
+open_arr = [1.0, 2.0, 3.0, 2.5, 2.0]
+high_arr = [1.5, 2.5, 3.5, 3.0, 2.5]
+low_arr = [0.5, 1.5, 2.5, 2.0, 1.5]
+close_arr = [1.2, 2.2, 3.2, 2.7, 2.1]
+
+
+# ############# Helpers ############# #
+
+def trace_dict(trace):
+    """Serialize a trace, stripping auto-generated widget `uid`s."""
+    d = trace.to_plotly_json()
+    d.pop("uid", None)
+    return d
+
+
+def shape_dict(shape):
+    """Serialize a shape for comparison."""
+    return shape.to_plotly_json()
+
+
+def assert_last_trace_matches(fig_under_test, expected_trace):
+    """Last trace on the figure must equal `expected_trace`."""
+    actual = trace_dict(fig_under_test.data[-1])
+    expected = trace_dict(expected_trace)
+    assert actual == expected, f"trace mismatch\nactual:   {actual}\nexpected: {expected}"
+
+
+def assert_last_shape_matches(fig_under_test, expected_shape_kwargs):
+    """Last shape on the figure must equal the shape produced by the expected kwargs."""
+    reference = go.Figure()
+    reference.add_shape(**expected_shape_kwargs)
+    actual = shape_dict(fig_under_test.layout.shapes[-1])
+    expected = shape_dict(reference.layout.shapes[-1])
+    assert actual == expected, f"shape mismatch\nactual:   {actual}\nexpected: {expected}"
+
+
+FIG_CLASSES = [Figure, FigureWidget]
+
+
+# ############# Protocol conformance ############# #
+
+class TestProtocolConformance:
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_isinstance_figure_protocol(self, cls):
+        """vbt figures structurally satisfy FigureProtocol."""
+        fig = cls()
+        assert isinstance(fig, FigureProtocol)
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_isinstance_base_figure(self, cls):
+        """vbt figures remain BaseFigure subclasses (no wrapping)."""
+        fig = cls()
+        assert isinstance(fig, BaseFigure)
+
+    def test_figure_still_go_figure(self):
+        """Figure is still a go.Figure subclass."""
+        assert isinstance(Figure(), go.Figure)
+
+    def test_figurewidget_still_go_figurewidget(self):
+        """FigureWidget is still a go.FigureWidget subclass (sibling of go.Figure)."""
+        assert isinstance(FigureWidget(), go.FigureWidget)
+        assert not isinstance(FigureWidget(), go.Figure)
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_native_returns_self(self, cls):
+        """`.native` returns the figure itself — no wrapping."""
+        fig = cls()
+        assert fig.native is fig
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_capabilities_has_all_flags(self, cls):
+        """Plotly-backed figures declare support for every capability flag."""
+        fig = cls()
+        for flag in Capability:
+            assert flag in fig.capabilities, f"missing capability: {flag.name}"
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_capabilities_is_class_level(self, cls):
+        """`capabilities` is a class-level constant, not a per-instance attribute."""
+        assert cls.capabilities is cls().capabilities
+
+
+# ############# add_line ############# #
+
+class TestPlotLine:
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_minimal(self, cls):
+        fig = cls()
+        fig.plot_line(x_arr, y_arr)
+        assert_last_trace_matches(fig, go.Scatter(x=x_arr, y=y_arr, mode="lines"))
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_with_name(self, cls):
+        fig = cls()
+        fig.plot_line(x_arr, y_arr, name="series")
+        assert_last_trace_matches(
+            fig, go.Scatter(x=x_arr, y=y_arr, mode="lines", name="series")
+        )
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_full_styling(self, cls):
+        fig = cls()
+        fig.plot_line(
+            x_arr, y_arr,
+            name="series",
+            color="red",
+            width=2.5,
+            dash="dash",
+            opacity=0.75,
+            showlegend=True,
+        )
+        assert_last_trace_matches(
+            fig,
+            go.Scatter(
+                x=x_arr, y=y_arr, mode="lines", name="series",
+                line=dict(color="red", width=2.5, dash="dash"),
+                opacity=0.75, showlegend=True,
+            ),
+        )
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_none_params_omitted(self, cls):
+        """Passing color=None must not emit an explicit `color: None` in the trace."""
+        fig = cls()
+        fig.plot_line(x_arr, y_arr, color=None, width=None, dash=None)
+        dumped = trace_dict(fig.data[-1])
+        assert "line" not in dumped
+
+
+# ############# add_markers ############# #
+
+class TestPlotMarkers:
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_minimal(self, cls):
+        fig = cls()
+        fig.plot_markers(x_arr, y_arr)
+        assert_last_trace_matches(fig, go.Scatter(x=x_arr, y=y_arr, mode="markers"))
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_full_styling(self, cls):
+        fig = cls()
+        fig.plot_markers(
+            x_arr, y_arr,
+            name="pts",
+            color="blue",
+            size=10,
+            symbol="triangle-up",
+            opacity=0.5,
+            showlegend=False,
+        )
+        assert_last_trace_matches(
+            fig,
+            go.Scatter(
+                x=x_arr, y=y_arr, mode="markers", name="pts",
+                marker=dict(color="blue", size=10, symbol="triangle-up"),
+                opacity=0.5, showlegend=False,
+            ),
+        )
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_line_color_only(self, cls):
+        fig = cls()
+        fig.plot_markers(x_arr, y_arr, line_color="red")
+        assert_last_trace_matches(
+            fig,
+            go.Scatter(
+                x=x_arr, y=y_arr, mode="markers",
+                marker=dict(line=dict(color="red")),
+            ),
+        )
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_line_width_only(self, cls):
+        fig = cls()
+        fig.plot_markers(x_arr, y_arr, line_width=2)
+        assert_last_trace_matches(
+            fig,
+            go.Scatter(
+                x=x_arr, y=y_arr, mode="markers",
+                marker=dict(line=dict(width=2)),
+            ),
+        )
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_line_color_and_width_combined(self, cls):
+        fig = cls()
+        fig.plot_markers(
+            x_arr, y_arr,
+            color="blue",
+            size=8,
+            symbol="circle",
+            line_color="darkblue",
+            line_width=1,
+        )
+        assert_last_trace_matches(
+            fig,
+            go.Scatter(
+                x=x_arr, y=y_arr, mode="markers",
+                marker=dict(
+                    color="blue",
+                    size=8,
+                    symbol="circle",
+                    line=dict(color="darkblue", width=1),
+                ),
+            ),
+        )
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_hover_text_scalar_broadcasts(self, cls):
+        fig = cls()
+        fig.plot_markers(x_arr, y_arr, hover_text="ping")
+        trace = fig.data[-1]
+        assert list(trace.customdata) == ["ping"] * len(x_arr)
+        assert trace.hovertemplate == "%{customdata}<extra></extra>"
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_hover_text_sequence_per_marker(self, cls):
+        fig = cls()
+        labels = [f"pt{i}" for i in range(len(x_arr))]
+        fig.plot_markers(x_arr, y_arr, hover_text=labels)
+        trace = fig.data[-1]
+        assert list(trace.customdata) == labels
+        assert trace.hovertemplate == "%{customdata}<extra></extra>"
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_hover_text_none_leaves_trace_unchanged(self, cls):
+        fig = cls()
+        fig.plot_markers(x_arr, y_arr)
+        trace = fig.data[-1]
+        assert trace.customdata is None
+        assert trace.hovertemplate is None
+
+
+# ############# add_ohlc ############# #
+
+class TestPlotOhlc:
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_minimal_produces_candlestick(self, cls):
+        """add_ohlc must emit a Candlestick, not an Ohlc (matches vectorbt convention)."""
+        fig = cls()
+        fig.plot_ohlc(x_arr, open_arr, high_arr, low_arr, close_arr)
+        assert fig.data[-1].type == "candlestick"
+        assert_last_trace_matches(
+            fig,
+            go.Candlestick(
+                x=x_arr, open=open_arr, high=high_arr, low=low_arr, close=close_arr
+            ),
+        )
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_with_colors(self, cls):
+        fig = cls()
+        fig.plot_ohlc(
+            x_arr, open_arr, high_arr, low_arr, close_arr,
+            name="OHLC",
+            increasing_color="green",
+            decreasing_color="orange",
+        )
+        assert_last_trace_matches(
+            fig,
+            go.Candlestick(
+                x=x_arr, open=open_arr, high=high_arr, low=low_arr, close=close_arr,
+                name="OHLC",
+                increasing=dict(line=dict(color="green")),
+                decreasing=dict(line=dict(color="orange")),
+            ),
+        )
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_style_default_is_candlestick(self, cls):
+        """Omitting style= must be byte-identical to style='candlestick'."""
+        fig_default = cls()
+        fig_default.plot_ohlc(x_arr, open_arr, high_arr, low_arr, close_arr)
+        fig_explicit = cls()
+        fig_explicit.plot_ohlc(
+            x_arr, open_arr, high_arr, low_arr, close_arr, style='candlestick'
+        )
+        assert trace_dict(fig_default.data[-1]) == trace_dict(fig_explicit.data[-1])
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_style_bars_minimal(self, cls):
+        fig = cls()
+        fig.plot_ohlc(
+            x_arr, open_arr, high_arr, low_arr, close_arr, style='bars'
+        )
+        assert fig.data[-1].type == "ohlc"
+        assert_last_trace_matches(
+            fig,
+            go.Ohlc(
+                x=x_arr, open=open_arr, high=high_arr, low=low_arr, close=close_arr
+            ),
+        )
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_style_bars_with_colors(self, cls):
+        fig = cls()
+        fig.plot_ohlc(
+            x_arr, open_arr, high_arr, low_arr, close_arr,
+            name="OHLC",
+            increasing_color="green",
+            decreasing_color="orange",
+            style='bars',
+        )
+        assert_last_trace_matches(
+            fig,
+            go.Ohlc(
+                x=x_arr, open=open_arr, high=high_arr, low=low_arr, close=close_arr,
+                name="OHLC",
+                increasing=dict(line=dict(color="green")),
+                decreasing=dict(line=dict(color="orange")),
+            ),
+        )
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_style_invalid_raises(self, cls):
+        fig = cls()
+        with pytest.raises(ValueError, match="style"):
+            fig.plot_ohlc(
+                x_arr, open_arr, high_arr, low_arr, close_arr, style='foo',
+            )
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_style_bars_subplot_routing(self, cls):
+        """style='bars' must route to row/col subplots the same way as candlestick."""
+        fig = make_subplots(rows=2, cols=1)
+        fig.plot_ohlc(
+            x_arr, open_arr, high_arr, low_arr, close_arr, style='bars',
+            row=2, col=1,
+        )
+        last = fig.data[-1]
+        assert last.type == "ohlc"
+        assert last.xaxis == 'x2'
+        assert last.yaxis == 'y2'
+
+
+# ############# add_histogram ############# #
+
+class TestPlotHistogram:
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_minimal(self, cls):
+        fig = cls()
+        fig.plot_histogram([1, 1, 2, 3, 3, 3])
+        assert fig.data[-1].type == "histogram"
+        assert_last_trace_matches(fig, go.Histogram(x=[1, 1, 2, 3, 3, 3]))
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_with_opacity_and_name(self, cls):
+        fig = cls()
+        fig.plot_histogram([1, 2, 3], name="h", opacity=0.6, showlegend=True)
+        assert_last_trace_matches(
+            fig,
+            go.Histogram(x=[1, 2, 3], name="h", opacity=0.6, showlegend=True),
+        )
+
+# ############# add_bars ############# #
+
+class TestPlotBars:
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_minimal(self, cls):
+        fig = cls()
+        fig.plot_bars(x_arr, y_arr)
+        assert fig.data[-1].type == "bar"
+        assert_last_trace_matches(fig, go.Bar(x=x_arr, y=y_arr))
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_with_name(self, cls):
+        fig = cls()
+        fig.plot_bars(x_arr, y_arr, name="series")
+        assert_last_trace_matches(fig, go.Bar(x=x_arr, y=y_arr, name="series"))
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_full_styling(self, cls):
+        fig = cls()
+        fig.plot_bars(
+            x_arr, y_arr,
+            name="series",
+            color="red",
+            opacity=0.75,
+            showlegend=True,
+        )
+        assert_last_trace_matches(
+            fig,
+            go.Bar(
+                x=x_arr, y=y_arr, name="series",
+                marker=dict(color="red"),
+                opacity=0.75, showlegend=True,
+            ),
+        )
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_none_params_omitted(self, cls):
+        """Passing color=None must not emit a `marker` block in the trace."""
+        fig = cls()
+        fig.plot_bars(x_arr, y_arr, color=None)
+        dumped = trace_dict(fig.data[-1])
+        assert "marker" not in dumped
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_color_array_minimal(self, cls):
+        """color as a list should produce per-bar colors via marker.color."""
+        fig = cls()
+        colors = ["red", "green", "blue", "yellow", "purple"]
+        fig.plot_bars(x_arr, y_arr, color=colors)
+        assert_last_trace_matches(
+            fig, go.Bar(x=x_arr, y=y_arr, marker=dict(color=colors)),
+        )
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_color_array_with_name(self, cls):
+        fig = cls()
+        colors = ["red", "green", "blue", "yellow", "purple"]
+        fig.plot_bars(x_arr, y_arr, name="volume", color=colors)
+        assert_last_trace_matches(
+            fig,
+            go.Bar(x=x_arr, y=y_arr, name="volume", marker=dict(color=colors)),
+        )
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_color_array_subplot_routing(self, cls):
+        """Per-bar colors must still route cleanly to row/col subplots."""
+        fig = make_subplots(rows=2, cols=1)
+        colors = ["red", "green", "blue", "yellow", "purple"]
+        fig.plot_bars(x_arr, y_arr, color=colors, row=2, col=1)
+        last = fig.data[-1]
+        assert last.type == "bar"
+        assert last.xaxis == 'x2'
+        assert last.yaxis == 'y2'
+        assert list(last.marker.color) == colors
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_line_width_zero(self, cls):
+        """line_width=0 should emit marker.line.width=0 for border suppression."""
+        fig = cls()
+        fig.plot_bars(x_arr, y_arr, line_width=0)
+        assert_last_trace_matches(
+            fig, go.Bar(x=x_arr, y=y_arr, marker=dict(line=dict(width=0))),
+        )
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_line_width_with_color(self, cls):
+        """line_width and color must both flow into the same marker dict."""
+        fig = cls()
+        colors = ["red", "green", "blue", "yellow", "purple"]
+        fig.plot_bars(x_arr, y_arr, color=colors, line_width=0)
+        assert_last_trace_matches(
+            fig,
+            go.Bar(
+                x=x_arr, y=y_arr,
+                marker=dict(color=colors, line=dict(width=0)),
+            ),
+        )
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_line_width_none_omitted(self, cls):
+        """line_width=None must not leak into the trace dict."""
+        fig = cls()
+        fig.plot_bars(x_arr, y_arr, line_width=None)
+        dumped = trace_dict(fig.data[-1])
+        assert "marker" not in dumped
+
+
+# ############# add_area ############# #
+
+class TestPlotArea:
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_minimal(self, cls):
+        fig = cls()
+        fig.plot_area(x_arr, y_arr)
+        assert_last_trace_matches(
+            fig, go.Scatter(x=x_arr, y=y_arr, mode="lines", fill="tozeroy")
+        )
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_with_colors(self, cls):
+        fig = cls()
+        fig.plot_area(
+            x_arr, y_arr,
+            name="fill",
+            color="purple",
+            fillcolor="rgba(128,0,128,0.3)",
+            showlegend=False,
+        )
+        assert_last_trace_matches(
+            fig,
+            go.Scatter(
+                x=x_arr, y=y_arr, mode="lines", fill="tozeroy", name="fill",
+                line=dict(color="purple"),
+                fillcolor="rgba(128,0,128,0.3)",
+                showlegend=False,
+            ),
+        )
+
+
+# ############# add_hline ############# #
+
+class TestPlotHline:
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_minimal_single_plot(self, cls):
+        fig = cls()
+        fig.plot_hline(y=5.0)
+        assert len(fig.layout.shapes) == 1
+        assert_last_shape_matches(
+            fig,
+            dict(type="line", xref="paper", yref="y", x0=0, x1=1, y0=5.0, y1=5.0),
+        )
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_with_styling(self, cls):
+        fig = cls()
+        fig.plot_hline(y=3.14, color="gray", dash="dash", width=1.5)
+        assert_last_shape_matches(
+            fig,
+            dict(
+                type="line",
+                xref="paper",
+                yref="y",
+                x0=0, x1=1, y0=3.14, y1=3.14,
+                line=dict(color="gray", dash="dash", width=1.5),
+            ),
+        )
+
+    def test_subplot_domain_resolution(self):
+        """Critical regression: plot_hline in a subplot must use vectorbt's pattern.
+
+        Pins the resolution chain: (row, col) -> get_subplot -> xaxis.plotly_name
+        -> get_domain(xref, fig) -> add_shape(xref='paper', yref='yN', x0/x1).
+        """
+        fig = make_subplots(rows=2, cols=1)
+        # Give row=2 real data so Plotly assigns x2/y2
+        fig.plot_line(x_arr, y_arr, row=2, col=1)
+        fig.plot_hline(y=7.0, row=2, col=1)
+
+        shape = fig.layout.shapes[-1]
+        assert shape.type == "line"
+        assert shape.xref == "paper"
+        assert shape.yref == "y2"
+        expected_domain = get_domain("x2", fig)
+        assert shape.x0 == expected_domain[0]
+        assert shape.x1 == expected_domain[1]
+        assert shape.y0 == 7.0
+        assert shape.y1 == 7.0
+
+    def test_subplot_row_1_uses_y1(self):
+        """Row 1 in a subplot figure still resolves to yref='y' (not 'y1')."""
+        fig = make_subplots(rows=2, cols=1)
+        fig.plot_line(x_arr, y_arr, row=1, col=1)
+        fig.plot_hline(y=1.0, row=1, col=1)
+        shape = fig.layout.shapes[-1]
+        assert shape.yref == "y"
+
+
+# ############# Subplot positioning ############# #
+
+class TestSubplotPositioning:
+    """row/col on the trace-producing methods must route to correct subplot axes."""
+
+    def test_add_line_row_col(self):
+        fig = make_subplots(rows=2, cols=1)
+        fig.plot_line(x_arr, y_arr, row=2, col=1)
+        assert fig.data[-1].xaxis == "x2"
+        assert fig.data[-1].yaxis == "y2"
+
+    def test_add_markers_row_col(self):
+        fig = make_subplots(rows=2, cols=1)
+        fig.plot_markers(x_arr, y_arr, row=2, col=1)
+        assert fig.data[-1].xaxis == "x2"
+        assert fig.data[-1].yaxis == "y2"
+
+    def test_add_area_row_col(self):
+        fig = make_subplots(rows=2, cols=1)
+        fig.plot_area(x_arr, y_arr, row=2, col=1)
+        assert fig.data[-1].xaxis == "x2"
+        assert fig.data[-1].yaxis == "y2"
+
+    def test_add_ohlc_row_col(self):
+        fig = make_subplots(rows=2, cols=1)
+        fig.plot_ohlc(x_arr, open_arr, high_arr, low_arr, close_arr, row=2, col=1)
+        assert fig.data[-1].xaxis == "x2"
+        assert fig.data[-1].yaxis == "y2"
+
+    def test_add_histogram_row_col(self):
+        fig = make_subplots(rows=2, cols=1)
+        fig.plot_histogram(y_arr, row=2, col=1)
+        assert fig.data[-1].xaxis == "x2"
+        assert fig.data[-1].yaxis == "y2"
+
+    def test_add_bars_row_col(self):
+        fig = make_subplots(rows=2, cols=1)
+        fig.plot_bars(x_arr, y_arr, row=2, col=1)
+        assert fig.data[-1].xaxis == "x2"
+        assert fig.data[-1].yaxis == "y2"
+
+
+# ############# Chainability ############# #
+
+class TestChainability:
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_all_methods_return_self(self, cls):
+        fig = cls()
+        assert fig.plot_line(x_arr, y_arr) is fig
+        assert fig.plot_markers(x_arr, y_arr) is fig
+        assert fig.plot_area(x_arr, y_arr) is fig
+        assert fig.plot_ohlc(x_arr, open_arr, high_arr, low_arr, close_arr) is fig
+        assert fig.plot_histogram(y_arr) is fig
+        assert fig.plot_bars(x_arr, y_arr) is fig
+        assert fig.plot_hline(y=3.0) is fig
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_fluent_chain(self, cls):
+        """Multiple methods chain cleanly on one figure."""
+        fig = cls()
+        result = (
+            fig.plot_line(x_arr, y_arr, name="a")
+               .plot_markers(x_arr, y_arr, name="b")
+               .plot_bars(x_arr, y_arr, name="c")
+               .plot_hline(y=4.0)
+        )
+        assert result is fig
+        assert len(fig.data) == 3
+        assert len(fig.layout.shapes) == 1
+
+
+# ############# make_figure factory ############# #
+
+class TestMakeFigureBackwardCompat:
+    """The make_figure factory still returns the extended classes."""
+
+    def test_returns_extended_class(self):
+        fig = make_figure()
+        assert isinstance(fig, (Figure, FigureWidget))
+        assert isinstance(fig, FigureProtocol)
+
+    def test_make_subplots_returns_extended_class(self):
+        fig = make_subplots(rows=2, cols=1)
+        assert isinstance(fig, (Figure, FigureWidget))
+        assert isinstance(fig, FigureProtocol)
+        assert fig.native is fig
+
+
+# ############# Plotly drop-in compatibility ############# #
+
+class TestPlotlyCompatibilityPreserved:
+    """Plotly's native methods must still work on vbt figures with their full kwargs.
+
+    Because the abstract protocol uses `plot_*` names rather than shadowing
+    Plotly's `add_*` family, every Plotly method remains reachable with its
+    original signature. This is the contract that lets vbt figures stay
+    drop-in replacements for `go.Figure` / `go.FigureWidget`.
+    """
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_add_hline_with_plotly_kwargs(self, cls):
+        """Plotly's `add_hline` with `annotation_text` and `line_color` still works."""
+        fig = cls()
+        fig.add_hline(y=5, annotation_text="target", line_color="red")
+        # Plotly's add_hline emits xref='x domain', not our xref='paper'
+        assert fig.layout.shapes[-1].xref == "x domain"
+        assert len(fig.layout.annotations) == 1
+        assert fig.layout.annotations[-1].text == "target"
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_add_ohlc_still_produces_ohlc_trace(self, cls):
+        """Plotly's `add_ohlc` still emits an `ohlc` trace, not a candlestick."""
+        fig = cls()
+        fig.add_ohlc(x=x_arr, open=open_arr, high=high_arr, low=low_arr, close=close_arr)
+        assert fig.data[-1].type == "ohlc"
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_add_histogram_accepts_nbinsx(self, cls):
+        """Plotly's `add_histogram(nbinsx=...)` still accepts Plotly-only kwargs."""
+        fig = cls()
+        fig.add_histogram(x=[1, 2, 3, 4, 5], nbinsx=3)
+        assert fig.data[-1].type == "histogram"
+        assert fig.data[-1].nbinsx == 3
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_add_trace_scatter_still_works(self, cls):
+        """`fig.add_trace(go.Scatter(...))` still works unchanged."""
+        fig = cls()
+        fig.add_trace(go.Scatter(x=[1, 2], y=[3, 4], mode="lines", name="s"))
+        assert len(fig.data) == 1
+        assert fig.data[-1].name == "s"
+
+    def test_plot_hline_and_add_hline_produce_different_shapes(self):
+        """Same-named concept, different implementations — proof that our methods coexist."""
+        fig = Figure()
+        fig.plot_hline(y=5)            # vbt: xref='paper'
+        fig.add_hline(y=5)             # plotly native: xref='x domain'
+        assert fig.layout.shapes[0].xref == "paper"
+        assert fig.layout.shapes[1].xref == "x domain"
+
+
+# ############# Input validation ############# #
+
+class TestInvalidSubplotCoordinates:
+    """Out-of-range row/col on a real subplot figure must propagate as ValueError.
+
+    Finding 2 from the Codex review: the earlier implementation silently caught
+    ValueError and fell back to the primary axes, which produced wrong charts
+    instead of errors. Only `TypeError` (plain, non-subplot figure) should be
+    caught as a fallback.
+    """
+
+    def test_plot_hline_out_of_range_row_raises(self):
+        fig = make_subplots(rows=2, cols=1)
+        with pytest.raises(ValueError):
+            fig.plot_hline(y=5, row=5, col=1)
+
+    def test_plot_hline_out_of_range_col_raises(self):
+        fig = make_subplots(rows=2, cols=1)
+        with pytest.raises(ValueError):
+            fig.plot_hline(y=5, row=1, col=5)
+
+    def test_plot_hline_on_plain_figure_uses_primary_axes(self):
+        """Plain (non-subplot) figures should still accept row/col without raising,
+        falling back to primary axes. This is the `TypeError` branch."""
+        fig = Figure()
+        fig.plot_hline(y=5, row=1, col=1)
+        assert fig.layout.shapes[-1].yref == "y"
+
+    def test_plot_hline_on_polar_cell_raises(self):
+        """Non-Cartesian subplot cells must raise rather than crash on missing xaxis."""
+        fig = make_subplots(rows=1, cols=1, specs=[[{'type': 'polar'}]])
+        with pytest.raises(TypeError, match="not a Cartesian"):
+            fig.plot_hline(y=1, row=1, col=1)
+
+    def test_plot_zone_on_polar_cell_raises(self):
+        """plot_zone must also reject non-Cartesian cells."""
+        fig = make_subplots(rows=1, cols=1, specs=[[{'type': 'polar'}]])
+        with pytest.raises(TypeError, match="not a Cartesian"):
+            fig.plot_zone(y0=0, y1=1, row=1, col=1)
+
+    def test_plot_hline_on_sparse_none_cell_raises(self):
+        """Empty cells in sparse layouts must raise, not silently misroute."""
+        fig = make_subplots(rows=1, cols=2, specs=[[None, {}]])
+        with pytest.raises(ValueError, match="No subplot"):
+            fig.plot_hline(y=1, row=1, col=1)
+
+    def test_plot_zone_on_sparse_none_cell_raises(self):
+        """plot_zone must also reject empty cells in sparse layouts."""
+        fig = make_subplots(rows=1, cols=2, specs=[[None, {}]])
+        with pytest.raises(ValueError, match="No subplot"):
+            fig.plot_zone(y0=0, y1=1, row=1, col=1)
+
+
+class TestPartialRowColValidation:
+    """Every `plot_*` method must reject partial (row xor col) subplot coordinates.
+
+    Before the fix, `plot_hline(row=2)` silently defaulted `col` to 1 while the
+    trace-producing methods raised. That inconsistency meant the same protocol
+    signature behaved differently depending on which method you called. Now the
+    shared `_validate_row_col` helper enforces "both or neither" everywhere.
+    """
+
+    def _call(self, method_name, fig, **extra):
+        fn = getattr(fig, method_name)
+        if method_name == "plot_hline":
+            return fn(y=5, **extra)
+        if method_name == "plot_ohlc":
+            return fn(x_arr, open_arr, high_arr, low_arr, close_arr, **extra)
+        if method_name == "plot_histogram":
+            return fn(y_arr, **extra)
+        return fn(x_arr, y_arr, **extra)
+
+    @pytest.mark.parametrize(
+        "method",
+        ["plot_line", "plot_markers", "plot_area", "plot_ohlc", "plot_histogram", "plot_bars", "plot_hline"],
+    )
+    def test_row_without_col_raises(self, method):
+        fig = make_subplots(rows=2, cols=1)
+        with pytest.raises(ValueError, match="row and col"):
+            self._call(method, fig, row=2)
+
+    @pytest.mark.parametrize(
+        "method",
+        ["plot_line", "plot_markers", "plot_area", "plot_ohlc", "plot_histogram", "plot_bars", "plot_hline"],
+    )
+    def test_col_without_row_raises(self, method):
+        fig = make_subplots(rows=2, cols=1)
+        with pytest.raises(ValueError, match="row and col"):
+            self._call(method, fig, col=1)

--- a/tests/test_plotting_protocol.py
+++ b/tests/test_plotting_protocol.py
@@ -13,6 +13,7 @@ import plotly.graph_objects as go
 import pytest
 from plotly.basedatatypes import BaseFigure
 
+import vectorbt as vbt
 from vectorbt.utils.figure import (
     Figure,
     FigureWidget,
@@ -67,6 +68,15 @@ def assert_last_shape_matches(fig_under_test, expected_shape_kwargs):
 FIG_CLASSES = [Figure, FigureWidget]
 
 
+@pytest.fixture(params=[True, False], ids=["FigureWidget", "Figure"])
+def use_widgets_setting(request):
+    """Parametrize over both Figure and FigureWidget for tests that go through make_subplots()."""
+    saved = vbt.settings['plotting']['use_widgets']
+    vbt.settings['plotting']['use_widgets'] = request.param
+    yield request.param
+    vbt.settings['plotting']['use_widgets'] = saved
+
+
 # ############# Protocol conformance ############# #
 
 class TestProtocolConformance:
@@ -96,6 +106,15 @@ class TestProtocolConformance:
         """`.native` returns the figure itself — no wrapping."""
         fig = cls()
         assert fig.native is fig
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_to_html_returns_string(self, cls):
+        """to_html() is declared on FigureProtocol and must return an HTML string."""
+        fig = cls()
+        fig.plot_line(x_arr, y_arr, name="smoke")
+        html = fig.to_html()
+        assert isinstance(html, str)
+        assert "<div" in html.lower()
 
     @pytest.mark.parametrize("cls", FIG_CLASSES)
     def test_capabilities_has_all_flags(self, cls):
@@ -253,6 +272,13 @@ class TestPlotMarkers:
         assert trace.hovertemplate == "%{customdata}<extra></extra>"
 
     @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_hover_text_sequence_length_mismatch_raises(self, cls):
+        """hover_text sequence whose length differs from x must raise ValueError."""
+        fig = cls()
+        with pytest.raises(ValueError, match="hover_text sequence length"):
+            fig.plot_markers(x_arr, y_arr, hover_text=["a"])
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
     def test_hover_text_none_leaves_trace_unchanged(self, cls):
         fig = cls()
         fig.plot_markers(x_arr, y_arr)
@@ -349,8 +375,7 @@ class TestPlotOhlc:
                 x_arr, open_arr, high_arr, low_arr, close_arr, style='foo',
             )
 
-    @pytest.mark.parametrize("cls", FIG_CLASSES)
-    def test_style_bars_subplot_routing(self, cls):
+    def test_style_bars_subplot_routing(self, use_widgets_setting):
         """style='bars' must route to row/col subplots the same way as candlestick."""
         fig = make_subplots(rows=2, cols=1)
         fig.plot_ohlc(
@@ -381,6 +406,15 @@ class TestPlotHistogram:
             fig,
             go.Histogram(x=[1, 2, 3], name="h", opacity=0.6, showlegend=True),
         )
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_none_params_omitted(self, cls):
+        """opacity=None and name=None must not leak into the trace dict."""
+        fig = cls()
+        fig.plot_histogram([1, 2, 3], name=None, opacity=None)
+        dumped = trace_dict(fig.data[-1])
+        assert "name" not in dumped
+        assert "opacity" not in dumped
 
 # ############# add_bars ############# #
 
@@ -445,8 +479,7 @@ class TestPlotBars:
             go.Bar(x=x_arr, y=y_arr, name="volume", marker=dict(color=colors)),
         )
 
-    @pytest.mark.parametrize("cls", FIG_CLASSES)
-    def test_color_array_subplot_routing(self, cls):
+    def test_color_array_subplot_routing(self, use_widgets_setting):
         """Per-bar colors must still route cleanly to row/col subplots."""
         fig = make_subplots(rows=2, cols=1)
         colors = ["red", "green", "blue", "yellow", "purple"]
@@ -520,6 +553,15 @@ class TestPlotArea:
             ),
         )
 
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_none_params_omitted(self, cls):
+        """color=None must not emit a line key; fillcolor=None must not emit fillcolor."""
+        fig = cls()
+        fig.plot_area(x_arr, y_arr, color=None, fillcolor=None)
+        dumped = trace_dict(fig.data[-1])
+        assert "line" not in dumped
+        assert "fillcolor" not in dumped
+
 
 # ############# add_hline ############# #
 
@@ -549,7 +591,7 @@ class TestPlotHline:
             ),
         )
 
-    def test_subplot_domain_resolution(self):
+    def test_subplot_domain_resolution(self, use_widgets_setting):
         """Critical regression: plot_hline in a subplot must use vectorbt's pattern.
 
         Pins the resolution chain: (row, col) -> get_subplot -> xaxis.plotly_name
@@ -570,11 +612,72 @@ class TestPlotHline:
         assert shape.y0 == 7.0
         assert shape.y1 == 7.0
 
-    def test_subplot_row_1_uses_y1(self):
+    def test_subplot_row_1_uses_y1(self, use_widgets_setting):
         """Row 1 in a subplot figure still resolves to yref='y' (not 'y1')."""
         fig = make_subplots(rows=2, cols=1)
         fig.plot_line(x_arr, y_arr, row=1, col=1)
         fig.plot_hline(y=1.0, row=1, col=1)
+        shape = fig.layout.shapes[-1]
+        assert shape.yref == "y"
+
+
+# ############# plot_zone ############# #
+
+class TestPlotZone:
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_minimal_single_plot(self, cls):
+        fig = cls()
+        fig.plot_zone(y0=1.0, y1=3.0)
+        assert len(fig.layout.shapes) == 1
+        assert_last_shape_matches(
+            fig,
+            dict(type="rect", xref="paper", yref="y",
+                 x0=0, x1=1, y0=1.0, y1=3.0,
+                 layer="below", line_width=0),
+        )
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_with_color_and_opacity(self, cls):
+        fig = cls()
+        fig.plot_zone(y0=2.0, y1=4.0, color="green", opacity=0.3)
+        assert_last_shape_matches(
+            fig,
+            dict(type="rect", xref="paper", yref="y",
+                 x0=0, x1=1, y0=2.0, y1=4.0,
+                 layer="below", line_width=0,
+                 fillcolor="green", opacity=0.3),
+        )
+
+    @pytest.mark.parametrize("cls", FIG_CLASSES)
+    def test_none_params_omitted(self, cls):
+        """color=None must not emit fillcolor; opacity=None must not emit opacity."""
+        fig = cls()
+        fig.plot_zone(y0=0.0, y1=1.0, color=None, opacity=None)
+        dumped = shape_dict(fig.layout.shapes[-1])
+        assert "fillcolor" not in dumped
+        assert "opacity" not in dumped
+
+    def test_subplot_domain_resolution(self, use_widgets_setting):
+        """plot_zone in a subplot must resolve yref and x-domain correctly."""
+        fig = make_subplots(rows=2, cols=1)
+        fig.plot_line(x_arr, y_arr, row=2, col=1)
+        fig.plot_zone(y0=1.0, y1=5.0, row=2, col=1)
+
+        shape = fig.layout.shapes[-1]
+        assert shape.type == "rect"
+        assert shape.xref == "paper"
+        assert shape.yref == "y2"
+        expected_domain = get_domain("x2", fig)
+        assert shape.x0 == expected_domain[0]
+        assert shape.x1 == expected_domain[1]
+        assert shape.y0 == 1.0
+        assert shape.y1 == 5.0
+
+    def test_subplot_row_1_uses_y(self, use_widgets_setting):
+        """Row 1 in a subplot figure still resolves to yref='y' (not 'y1')."""
+        fig = make_subplots(rows=2, cols=1)
+        fig.plot_line(x_arr, y_arr, row=1, col=1)
+        fig.plot_zone(y0=0.0, y1=2.0, row=1, col=1)
         shape = fig.layout.shapes[-1]
         assert shape.yref == "y"
 
@@ -584,41 +687,89 @@ class TestPlotHline:
 class TestSubplotPositioning:
     """row/col on the trace-producing methods must route to correct subplot axes."""
 
-    def test_add_line_row_col(self):
+    def test_add_line_row_col(self, use_widgets_setting):
         fig = make_subplots(rows=2, cols=1)
         fig.plot_line(x_arr, y_arr, row=2, col=1)
         assert fig.data[-1].xaxis == "x2"
         assert fig.data[-1].yaxis == "y2"
 
-    def test_add_markers_row_col(self):
+    def test_add_markers_row_col(self, use_widgets_setting):
         fig = make_subplots(rows=2, cols=1)
         fig.plot_markers(x_arr, y_arr, row=2, col=1)
         assert fig.data[-1].xaxis == "x2"
         assert fig.data[-1].yaxis == "y2"
 
-    def test_add_area_row_col(self):
+    def test_add_area_row_col(self, use_widgets_setting):
         fig = make_subplots(rows=2, cols=1)
         fig.plot_area(x_arr, y_arr, row=2, col=1)
         assert fig.data[-1].xaxis == "x2"
         assert fig.data[-1].yaxis == "y2"
 
-    def test_add_ohlc_row_col(self):
+    def test_add_ohlc_row_col(self, use_widgets_setting):
         fig = make_subplots(rows=2, cols=1)
         fig.plot_ohlc(x_arr, open_arr, high_arr, low_arr, close_arr, row=2, col=1)
         assert fig.data[-1].xaxis == "x2"
         assert fig.data[-1].yaxis == "y2"
 
-    def test_add_histogram_row_col(self):
+    def test_add_histogram_row_col(self, use_widgets_setting):
         fig = make_subplots(rows=2, cols=1)
         fig.plot_histogram(y_arr, row=2, col=1)
         assert fig.data[-1].xaxis == "x2"
         assert fig.data[-1].yaxis == "y2"
 
-    def test_add_bars_row_col(self):
+    def test_add_bars_row_col(self, use_widgets_setting):
         fig = make_subplots(rows=2, cols=1)
         fig.plot_bars(x_arr, y_arr, row=2, col=1)
         assert fig.data[-1].xaxis == "x2"
         assert fig.data[-1].yaxis == "y2"
+
+
+class TestSubplotColumnRouting:
+    """Exercises the col dimension of subplot routing, which the row=2, cols=1 tests do not cover.
+
+    Uses a 1x2 layout targeting col=2 for traces and a 2x2 layout for shapes,
+    so a regression that drops or ignores col would be caught.
+    """
+
+    def test_line_col_2(self, use_widgets_setting):
+        fig = make_subplots(rows=1, cols=2)
+        fig.plot_line(x_arr, y_arr, row=1, col=2)
+        assert fig.data[-1].xaxis == "x2"
+        assert fig.data[-1].yaxis == "y2"
+
+    def test_markers_col_2(self, use_widgets_setting):
+        fig = make_subplots(rows=1, cols=2)
+        fig.plot_markers(x_arr, y_arr, row=1, col=2)
+        assert fig.data[-1].xaxis == "x2"
+        assert fig.data[-1].yaxis == "y2"
+
+    def test_bars_col_2(self, use_widgets_setting):
+        fig = make_subplots(rows=1, cols=2)
+        fig.plot_bars(x_arr, y_arr, row=1, col=2)
+        assert fig.data[-1].xaxis == "x2"
+        assert fig.data[-1].yaxis == "y2"
+
+    def test_hline_col_2_domain(self, use_widgets_setting):
+        """plot_hline in col=2 of a 2x2 layout must resolve to correct yref and x-domain."""
+        fig = make_subplots(rows=2, cols=2)
+        fig.plot_line(x_arr, y_arr, row=1, col=2)
+        fig.plot_hline(y=3.0, row=1, col=2)
+        shape = fig.layout.shapes[-1]
+        assert shape.yref == "y2"
+        expected_domain = get_domain("x2", fig)
+        assert shape.x0 == expected_domain[0]
+        assert shape.x1 == expected_domain[1]
+
+    def test_zone_col_2_domain(self, use_widgets_setting):
+        """plot_zone in col=2 of a 2x2 layout must resolve to correct yref and x-domain."""
+        fig = make_subplots(rows=2, cols=2)
+        fig.plot_line(x_arr, y_arr, row=1, col=2)
+        fig.plot_zone(y0=1.0, y1=5.0, row=1, col=2)
+        shape = fig.layout.shapes[-1]
+        assert shape.yref == "y2"
+        expected_domain = get_domain("x2", fig)
+        assert shape.x0 == expected_domain[0]
+        assert shape.x1 == expected_domain[1]
 
 
 # ############# Chainability ############# #
@@ -634,6 +785,7 @@ class TestChainability:
         assert fig.plot_histogram(y_arr) is fig
         assert fig.plot_bars(x_arr, y_arr) is fig
         assert fig.plot_hline(y=3.0) is fig
+        assert fig.plot_zone(y0=1.0, y1=2.0) is fig
 
     @pytest.mark.parametrize("cls", FIG_CLASSES)
     def test_fluent_chain(self, cls):
@@ -644,10 +796,11 @@ class TestChainability:
                .plot_markers(x_arr, y_arr, name="b")
                .plot_bars(x_arr, y_arr, name="c")
                .plot_hline(y=4.0)
+               .plot_zone(y0=1.0, y1=2.0)
         )
         assert result is fig
         assert len(fig.data) == 3
-        assert len(fig.layout.shapes) == 1
+        assert len(fig.layout.shapes) == 2
 
 
 # ############# make_figure factory ############# #
@@ -680,13 +833,18 @@ class TestPlotlyCompatibilityPreserved:
 
     @pytest.mark.parametrize("cls", FIG_CLASSES)
     def test_add_hline_with_plotly_kwargs(self, cls):
-        """Plotly's `add_hline` with `annotation_text` and `line_color` still works."""
+        """Plotly's `add_hline` with `annotation_text` and `line_color` still works.
+
+        Compared against a plain go.Figure reference so the test survives
+        upstream changes to Plotly's internal serialization details.
+        """
         fig = cls()
         fig.add_hline(y=5, annotation_text="target", line_color="red")
-        # Plotly's add_hline emits xref='x domain', not our xref='paper'
-        assert fig.layout.shapes[-1].xref == "x domain"
-        assert len(fig.layout.annotations) == 1
-        assert fig.layout.annotations[-1].text == "target"
+        ref = go.Figure()
+        ref.add_hline(y=5, annotation_text="target", line_color="red")
+        assert shape_dict(fig.layout.shapes[-1]) == shape_dict(ref.layout.shapes[-1])
+        assert len(fig.layout.annotations) == len(ref.layout.annotations)
+        assert fig.layout.annotations[-1].text == ref.layout.annotations[-1].text
 
     @pytest.mark.parametrize("cls", FIG_CLASSES)
     def test_add_ohlc_still_produces_ohlc_trace(self, cls):
@@ -786,6 +944,8 @@ class TestPartialRowColValidation:
         fn = getattr(fig, method_name)
         if method_name == "plot_hline":
             return fn(y=5, **extra)
+        if method_name == "plot_zone":
+            return fn(y0=0, y1=1, **extra)
         if method_name == "plot_ohlc":
             return fn(x_arr, open_arr, high_arr, low_arr, close_arr, **extra)
         if method_name == "plot_histogram":
@@ -794,7 +954,7 @@ class TestPartialRowColValidation:
 
     @pytest.mark.parametrize(
         "method",
-        ["plot_line", "plot_markers", "plot_area", "plot_ohlc", "plot_histogram", "plot_bars", "plot_hline"],
+        ["plot_line", "plot_markers", "plot_area", "plot_ohlc", "plot_histogram", "plot_bars", "plot_hline", "plot_zone"],
     )
     def test_row_without_col_raises(self, method):
         fig = make_subplots(rows=2, cols=1)
@@ -803,7 +963,7 @@ class TestPartialRowColValidation:
 
     @pytest.mark.parametrize(
         "method",
-        ["plot_line", "plot_markers", "plot_area", "plot_ohlc", "plot_histogram", "plot_bars", "plot_hline"],
+        ["plot_line", "plot_markers", "plot_area", "plot_ohlc", "plot_histogram", "plot_bars", "plot_hline", "plot_zone"],
     )
     def test_col_without_row_raises(self, method):
         fig = make_subplots(rows=2, cols=1)

--- a/tests/test_plotting_renderer.py
+++ b/tests/test_plotting_renderer.py
@@ -1,11 +1,11 @@
-"""Tests for the plotting backend registry, `create_figure` factory,
-and the `default_backend` setting.
+"""Tests for the plotting renderer registry, `create_figure` factory,
+and the `default_renderer` setting.
 
 These tests cover:
 - registry round-trip, validation, and override semantics
 - the `_plotly_factory` router (no-args -> make_figure;
   explicit rows/cols or subplot-only kwargs -> make_subplots)
-- runtime mutation of `settings['plotting']['default_backend']`
+- runtime mutation of `settings['plotting']['default_renderer']`
 - public API exposure on `vbt.plotting.*` and top-level `vbt.*`
 """
 
@@ -19,20 +19,20 @@ from vectorbt.utils.figure import (
     assert_plotly_only_kwargs,
     assert_plotly_only_method,
     create_figure,
-    get_backend,
-    list_backends,
+    get_renderer,
+    list_renderers,
     make_figure,
     make_subplots,
-    register_backend,
-    resolve_backend,
-    resolve_backend_for_fig,
+    register_renderer,
+    resolve_renderer,
+    resolve_renderer_for_fig,
 )
 from vectorbt.utils.plotting_protocol import Capability, FigureProtocol
 
 
 class _StubNonPlotlyFig:
     """Minimal non-Plotly figure for testing resolution helpers."""
-    backend_name = 'stub'
+    renderer_name = 'stub'
 
 
 def _strip_uid(node):
@@ -44,82 +44,82 @@ def _strip_uid(node):
 
 
 @pytest.fixture(autouse=True)
-def _restore_backend_state():
-    saved_registry = dict(_figure_mod._BACKEND_REGISTRY)
-    saved_default = vbt.settings['plotting']['default_backend']
+def _restore_renderer_state():
+    saved_registry = dict(_figure_mod._RENDERER_REGISTRY)
+    saved_default = vbt.settings['plotting']['default_renderer']
     saved_use_widgets = vbt.settings['plotting']['use_widgets']
     try:
         yield
     finally:
-        _figure_mod._BACKEND_REGISTRY.clear()
-        _figure_mod._BACKEND_REGISTRY.update(saved_registry)
-        vbt.settings['plotting']['default_backend'] = saved_default
+        _figure_mod._RENDERER_REGISTRY.clear()
+        _figure_mod._RENDERER_REGISTRY.update(saved_registry)
+        vbt.settings['plotting']['default_renderer'] = saved_default
         vbt.settings['plotting']['use_widgets'] = saved_use_widgets
 
 
 class TestRegistryDefaults:
-    def test_default_backend_is_plotly(self):
-        assert 'plotly' in list_backends()
-        assert vbt.settings['plotting']['default_backend'] == 'plotly'
+    def test_default_renderer_is_plotly(self):
+        assert 'plotly' in list_renderers()
+        assert vbt.settings['plotting']['default_renderer'] == 'plotly'
 
 
-class TestBackendNameAttribute:
-    def test_plotly_backend_name(self):
+class TestRendererNameAttribute:
+    def test_plotly_renderer_name(self):
         from vectorbt.utils.figure import PlotlyFigureProtocolMixin
-        assert PlotlyFigureProtocolMixin.backend_name == 'plotly'
+        assert PlotlyFigureProtocolMixin.renderer_name == 'plotly'
         fig = make_figure()
-        assert type(fig).backend_name == 'plotly'
+        assert type(fig).renderer_name == 'plotly'
 
 
-class TestResolveBackendForFig:
+class TestResolveRendererForFig:
     def test_none_defaults_to_plotly(self):
-        vbt.settings['plotting']['default_backend'] = 'plotly'
-        backend, is_plotly = resolve_backend_for_fig(None)
-        assert backend == 'plotly'
+        vbt.settings['plotting']['default_renderer'] = 'plotly'
+        renderer, is_plotly = resolve_renderer_for_fig(None)
+        assert renderer == 'plotly'
         assert is_plotly is True
 
     def test_none_defaults_to_custom(self):
-        vbt.settings['plotting']['default_backend'] = 'other'
-        backend, is_plotly = resolve_backend_for_fig(None)
-        assert backend == 'other'
+        vbt.settings['plotting']['default_renderer'] = 'other'
+        renderer, is_plotly = resolve_renderer_for_fig(None)
+        assert renderer == 'other'
         assert is_plotly is False
 
     def test_plotly_figure_instance(self):
         fig = make_figure()
-        backend, is_plotly = resolve_backend_for_fig(fig)
-        assert backend == 'plotly'
+        renderer, is_plotly = resolve_renderer_for_fig(fig)
+        assert renderer == 'plotly'
         assert is_plotly is True
 
     def test_plotly_subplots_instance(self):
         fig = make_subplots(rows=2, cols=1)
-        backend, is_plotly = resolve_backend_for_fig(fig)
-        assert backend == 'plotly'
+        renderer, is_plotly = resolve_renderer_for_fig(fig)
+        assert renderer == 'plotly'
         assert is_plotly is True
 
     def test_stub_figure_instance(self):
         fig = _StubNonPlotlyFig()
-        backend, is_plotly = resolve_backend_for_fig(fig)
-        assert backend == 'stub'
+        renderer, is_plotly = resolve_renderer_for_fig(fig)
+        assert renderer == 'stub'
         assert is_plotly is False
 
-    def test_third_party_backend_uses_class_attribute(self):
+    def test_third_party_renderer_uses_class_attribute(self):
         class FakeFig:
-            backend_name = 'bokeh'
-        backend, is_plotly = resolve_backend_for_fig(FakeFig())
-        assert backend == 'bokeh'
+            renderer_name = 'bokeh'
+        renderer, is_plotly = resolve_renderer_for_fig(FakeFig())
+        assert renderer == 'bokeh'
         assert is_plotly is False
 
-    def test_third_party_backend_falls_back_to_class_name(self):
+    def test_third_party_renderer_falls_back_to_class_name(self):
         class UnnamedFig:
             pass
-        backend, is_plotly = resolve_backend_for_fig(UnnamedFig())
-        assert backend == 'UnnamedFig'
+        renderer, is_plotly = resolve_renderer_for_fig(UnnamedFig())
+        assert renderer == 'UnnamedFig'
         assert is_plotly is False
 
 
 class TestAssertPlotlyOnlyKwargs:
     def test_noop_when_forcing_empty(self):
-        # No raise even on non-Plotly backend.
+        # No raise even on non-Plotly renderer.
         assert_plotly_only_kwargs(False, 'other', [], method_name='Foo.plot')
 
     def test_noop_when_plotly(self):
@@ -139,7 +139,7 @@ class TestAssertPlotlyOnlyKwargs:
         assert 'layout_kwargs' in msg
         assert 'legacy Plotly-specific escape hatches' in msg
 
-    def test_raises_mentions_third_party_backend_name(self):
+    def test_raises_mentions_third_party_renderer_name(self):
         with pytest.raises(NotImplementedError) as exc:
             assert_plotly_only_kwargs(
                 False, 'bokeh', ['trace_kwargs'],
@@ -235,7 +235,7 @@ class TestCreateFigureRouting:
 
 
 class TestRegistryAPI:
-    def test_register_backend_roundtrip(self):
+    def test_register_renderer_roundtrip(self):
         called = []
         sentinel = object()
 
@@ -243,12 +243,12 @@ class TestRegistryAPI:
             called.append((rows, cols, kw))
             return sentinel
 
-        register_backend('dummy', _dummy)
-        assert 'dummy' in list_backends()
-        assert create_figure(backend='dummy') is sentinel
+        register_renderer('dummy', _dummy)
+        assert 'dummy' in list_renderers()
+        assert create_figure(renderer='dummy') is sentinel
         assert called == [(None, None, {})]
 
-    def test_register_backend_forwards_kwargs(self):
+    def test_register_renderer_forwards_kwargs(self):
         """create_figure must forward rows, cols, and extra kwargs to the factory."""
         called = []
 
@@ -256,57 +256,57 @@ class TestRegistryAPI:
             called.append((rows, cols, kw))
             return 'dummy-figure'
 
-        register_backend('dummy', _dummy)
-        create_figure(backend='dummy', rows=3, cols=2, shared_xaxes=True)
+        register_renderer('dummy', _dummy)
+        create_figure(renderer='dummy', rows=3, cols=2, shared_xaxes=True)
         assert called == [(3, 2, {'shared_xaxes': True})]
 
-    def test_register_backend_duplicate_raises(self):
+    def test_register_renderer_duplicate_raises(self):
         with pytest.raises(ValueError, match="already registered"):
-            register_backend('plotly', lambda **kw: None)
+            register_renderer('plotly', lambda **kw: None)
 
-    def test_register_backend_override_allowed(self):
+    def test_register_renderer_override_allowed(self):
         def replacement(**kw):
             return 'replaced'
-        register_backend('plotly', replacement, override=True)
-        assert get_backend('plotly') is replacement
+        register_renderer('plotly', replacement, override=True)
+        assert get_renderer('plotly') is replacement
 
-    def test_unknown_backend_raises_keyerror(self):
+    def test_unknown_renderer_raises_keyerror(self):
         with pytest.raises(KeyError, match="nope"):
-            create_figure(backend='nope')
+            create_figure(renderer='nope')
 
-    def test_unregistered_default_backend_raises_keyerror(self):
-        """When the default_backend setting points to an unknown name,
-        create_figure() without explicit backend= must raise KeyError."""
-        vbt.settings['plotting']['default_backend'] = 'nonexistent'
+    def test_unregistered_default_renderer_raises_keyerror(self):
+        """When the default_renderer setting points to an unknown name,
+        create_figure() without explicit renderer= must raise KeyError."""
+        vbt.settings['plotting']['default_renderer'] = 'nonexistent'
         with pytest.raises(KeyError, match="nonexistent"):
             create_figure()
 
-    def test_settings_override_default_backend(self):
+    def test_settings_override_default_renderer(self):
         called = []
 
         def _dummy(*, rows, cols, **kw):
             called.append((rows, cols, kw))
             return 'dummy-figure'
 
-        register_backend('dummy', _dummy)
-        vbt.settings['plotting']['default_backend'] = 'dummy'
+        register_renderer('dummy', _dummy)
+        vbt.settings['plotting']['default_renderer'] = 'dummy'
         result = create_figure()
         assert result == 'dummy-figure'
         assert called == [(None, None, {})]
 
-    def test_register_backend_validation(self):
+    def test_register_renderer_validation(self):
         with pytest.raises(ValueError):
-            register_backend('', lambda **kw: None)
+            register_renderer('', lambda **kw: None)
         with pytest.raises(TypeError):
-            register_backend('bad', 'not-callable')
+            register_renderer('bad', 'not-callable')
 
 
 class TestPublicAPIExposure:
     def test_create_figure_exposed_via_vbt_plotting(self):
         assert vbt.plotting.create_figure is create_figure
-        assert vbt.plotting.register_backend is register_backend
-        assert vbt.plotting.get_backend is get_backend
-        assert vbt.plotting.list_backends is list_backends
+        assert vbt.plotting.register_renderer is register_renderer
+        assert vbt.plotting.get_renderer is get_renderer
+        assert vbt.plotting.list_renderers is list_renderers
         assert vbt.plotting.FigureProtocol is FigureProtocol
         assert vbt.plotting.Capability is Capability
         fig = vbt.plotting.create_figure()
@@ -314,9 +314,9 @@ class TestPublicAPIExposure:
 
     def test_create_figure_exposed_at_top_level(self):
         assert vbt.create_figure is create_figure
-        assert vbt.register_backend is register_backend
-        assert vbt.get_backend is get_backend
-        assert vbt.list_backends is list_backends
+        assert vbt.register_renderer is register_renderer
+        assert vbt.get_renderer is get_renderer
+        assert vbt.list_renderers is list_renderers
         a = vbt.create_figure()
         b = vbt.make_figure()
         assert isinstance(a, (Figure, FigureWidget))
@@ -333,56 +333,56 @@ class TestPublicAPIExposure:
         assert hasattr(vbt.plotting, 'Volume')
 
 
-class TestResolveBackend:
-    """Tests for the resolve_backend() helper."""
+class TestResolveRenderer:
+    """Tests for the resolve_renderer() helper."""
 
     def test_both_none_uses_default_plotly(self):
-        vbt.settings['plotting']['default_backend'] = 'plotly'
-        backend, is_plotly = resolve_backend(None, None)
-        assert backend == 'plotly'
+        vbt.settings['plotting']['default_renderer'] = 'plotly'
+        renderer, is_plotly = resolve_renderer(None, None)
+        assert renderer == 'plotly'
         assert is_plotly is True
 
     def test_both_none_uses_default_custom(self):
-        vbt.settings['plotting']['default_backend'] = 'other'
-        backend, is_plotly = resolve_backend(None, None)
-        assert backend == 'other'
+        vbt.settings['plotting']['default_renderer'] = 'other'
+        renderer, is_plotly = resolve_renderer(None, None)
+        assert renderer == 'other'
         assert is_plotly is False
 
-    def test_backend_override_alone(self):
-        backend, is_plotly = resolve_backend(None, 'other')
-        assert backend == 'other'
+    def test_renderer_override_alone(self):
+        renderer, is_plotly = resolve_renderer(None, 'other')
+        assert renderer == 'other'
         assert is_plotly is False
 
-    def test_backend_override_plotly(self):
-        vbt.settings['plotting']['default_backend'] = 'other'
-        backend, is_plotly = resolve_backend(None, 'plotly')
-        assert backend == 'plotly'
+    def test_renderer_override_plotly(self):
+        vbt.settings['plotting']['default_renderer'] = 'other'
+        renderer, is_plotly = resolve_renderer(None, 'plotly')
+        assert renderer == 'plotly'
         assert is_plotly is True
 
     def test_fig_alone_plotly(self):
         fig = make_figure()
-        backend, is_plotly = resolve_backend(fig, None)
-        assert backend == 'plotly'
+        renderer, is_plotly = resolve_renderer(fig, None)
+        assert renderer == 'plotly'
         assert is_plotly is True
 
     def test_fig_alone_stub(self):
         fig = _StubNonPlotlyFig()
-        backend, is_plotly = resolve_backend(fig, None)
-        assert backend == 'stub'
+        renderer, is_plotly = resolve_renderer(fig, None)
+        assert renderer == 'stub'
         assert is_plotly is False
 
-    def test_fig_and_matching_backend(self):
+    def test_fig_and_matching_renderer(self):
         fig = make_figure()
-        backend, is_plotly = resolve_backend(fig, 'plotly')
-        assert backend == 'plotly'
+        renderer, is_plotly = resolve_renderer(fig, 'plotly')
+        assert renderer == 'plotly'
         assert is_plotly is True
 
-    def test_fig_and_conflicting_backend_raises(self):
+    def test_fig_and_conflicting_renderer_raises(self):
         fig = make_figure()
         with pytest.raises(ValueError, match="conflicts"):
-            resolve_backend(fig, 'other')
+            resolve_renderer(fig, 'other')
 
-    def test_stub_fig_and_conflicting_backend_raises(self):
+    def test_stub_fig_and_conflicting_renderer_raises(self):
         fig = _StubNonPlotlyFig()
         with pytest.raises(ValueError, match="conflicts"):
-            resolve_backend(fig, 'plotly')
+            resolve_renderer(fig, 'plotly')

--- a/vectorbt/_settings.py
+++ b/vectorbt/_settings.py
@@ -154,10 +154,10 @@ settings = SettingsConfig(
         ),
         plotting=dict(
             use_widgets=True,
-            # Default backend used by `vbt.create_figure(...)`. Existing
+            # Default renderer used by `vbt.create_figure(...)`. Existing
             # `make_figure` / `make_subplots`-based plot methods are
             # unaffected -- they will be migrated in follow-up issues.
-            default_backend='plotly',
+            default_renderer='plotly',
             show_kwargs=Config(),  # flex
             color_schema=Config(dict(increasing="#1b9e76", decreasing="#d95f02")),  # flex
             contrast_color_schema=Config(  # flex

--- a/vectorbt/_settings.py
+++ b/vectorbt/_settings.py
@@ -154,6 +154,10 @@ settings = SettingsConfig(
         ),
         plotting=dict(
             use_widgets=True,
+            # Default backend used by `vbt.create_figure(...)`. Existing
+            # `make_figure` / `make_subplots`-based plot methods are
+            # unaffected -- they will be migrated in follow-up issues.
+            default_backend='plotly',
             show_kwargs=Config(),  # flex
             color_schema=Config(dict(increasing="#1b9e76", decreasing="#d95f02")),  # flex
             contrast_color_schema=Config(  # flex

--- a/vectorbt/generic/plotting.py
+++ b/vectorbt/generic/plotting.py
@@ -27,6 +27,16 @@ from vectorbt.utils.array_ import renormalize
 from vectorbt.utils.colors import rgb_from_cmap
 from vectorbt.utils.config import Configured, resolve_dict
 from vectorbt.utils.figure import make_figure
+from vectorbt.utils.figure import (  # noqa: F401  exposed as vbt.plotting.*
+    create_figure,
+    register_backend,
+    get_backend,
+    list_backends,
+)
+from vectorbt.utils.plotting_protocol import (  # noqa: F401  exposed as vbt.plotting.*
+    FigureProtocol,
+    Capability,
+)
 
 
 def clean_labels(labels: tp.ArrayLikeSequence) -> tp.ArrayLikeSequence:

--- a/vectorbt/generic/plotting.py
+++ b/vectorbt/generic/plotting.py
@@ -29,9 +29,9 @@ from vectorbt.utils.config import Configured, resolve_dict
 from vectorbt.utils.figure import make_figure
 from vectorbt.utils.figure import (  # noqa: F401  exposed as vbt.plotting.*
     create_figure,
-    register_backend,
-    get_backend,
-    list_backends,
+    register_renderer,
+    get_renderer,
+    list_renderers,
 )
 from vectorbt.utils.plotting_protocol import (  # noqa: F401  exposed as vbt.plotting.*
     FigureProtocol,

--- a/vectorbt/utils/__init__.py
+++ b/vectorbt/utils/__init__.py
@@ -5,7 +5,16 @@
 
 from vectorbt.utils.config import atomic_dict, merge_dicts, Config, Configured, AtomicConfig
 from vectorbt.utils.decorators import CacheCondition, cached_property, cached_method
-from vectorbt.utils.figure import Figure, FigureWidget, make_figure, make_subplots
+from vectorbt.utils.figure import (
+    Figure,
+    FigureWidget,
+    make_figure,
+    make_subplots,
+    create_figure,
+    register_backend,
+    get_backend,
+    list_backends,
+)
 from vectorbt.utils.image_ import save_animation
 from vectorbt.utils.random_ import set_seed
 from vectorbt.utils.schedule_ import AsyncJob, AsyncScheduler, CancelledError, ScheduleManager
@@ -29,6 +38,10 @@ __all__ = [
     "FigureWidget",
     "make_figure",
     "make_subplots",
+    "create_figure",
+    "register_backend",
+    "get_backend",
+    "list_backends",
     "set_seed",
     "save_animation",
     "AsyncJob",

--- a/vectorbt/utils/__init__.py
+++ b/vectorbt/utils/__init__.py
@@ -11,9 +11,9 @@ from vectorbt.utils.figure import (
     make_figure,
     make_subplots,
     create_figure,
-    register_backend,
-    get_backend,
-    list_backends,
+    register_renderer,
+    get_renderer,
+    list_renderers,
 )
 from vectorbt.utils.image_ import save_animation
 from vectorbt.utils.random_ import set_seed
@@ -39,9 +39,9 @@ __all__ = [
     "make_figure",
     "make_subplots",
     "create_figure",
-    "register_backend",
-    "get_backend",
-    "list_backends",
+    "register_renderer",
+    "get_renderer",
+    "list_renderers",
     "set_seed",
     "save_animation",
     "AsyncJob",

--- a/vectorbt/utils/figure.py
+++ b/vectorbt/utils/figure.py
@@ -192,6 +192,12 @@ class PlotlyFigureProtocolMixin:
                 customdata = [hover_text] * n_points if n_points is not None else [hover_text]
             else:
                 customdata = list(hover_text)
+                n_points = len(x) if hasattr(x, '__len__') else None
+                if n_points is not None and len(customdata) != n_points:
+                    raise ValueError(
+                        f"hover_text sequence length ({len(customdata)}) must match "
+                        f"the number of data points ({n_points})"
+                    )
             trace_kwargs['customdata'] = customdata
             trace_kwargs['hovertemplate'] = '%{customdata}<extra></extra>'
         self.add_trace(go.Scatter(**trace_kwargs), **_add_trace_kwargs(row, col))

--- a/vectorbt/utils/figure.py
+++ b/vectorbt/utils/figure.py
@@ -3,11 +3,25 @@
 
 """Utilities for constructing and displaying figures."""
 
+import plotly.graph_objects as go
 from plotly.graph_objects import Figure as _Figure, FigureWidget as _FigureWidget
 from plotly.subplots import make_subplots as _make_subplots
 
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
+
 from vectorbt import _typing as tp
 from vectorbt.utils.config import merge_dicts
+from vectorbt.utils.plotting_protocol import Capability, FigureProtocol
+
+_ALL_CAPABILITIES = (
+    Capability.TIME_SERIES | Capability.OHLC | Capability.LINE | Capability.AREA
+    | Capability.HISTOGRAM | Capability.BAR | Capability.MARKERS | Capability.HLINE
+    | Capability.ZONE | Capability.GAUGE | Capability.HEATMAP | Capability.BOX
+    | Capability.SCATTER_XY | Capability.VOLUME_3D
+)
 
 
 def get_domain(ref: str, fig: tp.BaseFigure) -> tp.Tuple[int, int]:
@@ -20,7 +34,75 @@ def get_domain(ref: str, fig: tp.BaseFigure) -> tp.Tuple[int, int]:
     return 0, 1
 
 
-class FigureMixin:
+def _validate_row_col(row: tp.Optional[int], col: tp.Optional[int]) -> None:
+    """Require `row` and `col` to be both None or both non-None.
+
+    Matches Plotly's own `add_trace` contract and keeps every `plot_*`
+    method consistent — either none of the subplot coordinates, or both.
+    """
+    if (row is None) != (col is None):
+        raise ValueError("row and col must be specified together")
+
+
+def _resolve_subplot_axes(fig: tp.BaseFigure,
+                          row: tp.Optional[int],
+                          col: tp.Optional[int]) -> tp.Tuple[str, str]:
+    """Resolve (row, col) to (xref, yref) strings, defaulting to 'x'/'y'.
+
+    Falls back to the primary axes only on plain (non-subplot) figures, where
+    `get_subplot` raises `TypeError`. Out-of-range coordinates on a real subplot
+    figure raise `ValueError` and are allowed to propagate so bad inputs surface
+    cleanly rather than silently drawing on the wrong axes.
+
+    Raises `ValueError` when the target cell is empty (``specs=None``) in a
+    sparse layout, and `TypeError` when the cell holds a non-Cartesian subplot
+    (e.g. polar, ternary) that has no x/y axis pair.
+    """
+    _validate_row_col(row, col)
+    if row is None and col is None:
+        return 'x', 'y'
+    try:
+        subplot = fig.get_subplot(row, col)
+    except TypeError:
+        # Plain (non-subplot) figure — fall back to primary axes.
+        return 'x', 'y'
+    if subplot is None:
+        raise ValueError(
+            f"No subplot at row={row}, col={col}. The cell may be empty "
+            f"(specs=None) in a sparse subplot layout."
+        )
+    if not hasattr(subplot, 'xaxis') or not hasattr(subplot, 'yaxis'):
+        raise TypeError(
+            f"Subplot at row={row}, col={col} is not a Cartesian (XY) cell "
+            f"(got {type(subplot).__name__}). plot_hline and plot_zone "
+            f"require Cartesian subplots."
+        )
+    xref = subplot.xaxis.plotly_name.replace('axis', '')
+    yref = subplot.yaxis.plotly_name.replace('axis', '')
+    return xref, yref
+
+
+def _add_trace_kwargs(row: tp.Optional[int],
+                      col: tp.Optional[int]) -> tp.Kwargs:
+    """Build add_trace keyword arguments for optional row/col positioning."""
+    _validate_row_col(row, col)
+    kwargs: tp.Kwargs = {}
+    if row is not None:
+        kwargs['row'] = row
+    if col is not None:
+        kwargs['col'] = col
+    return kwargs
+
+
+class PlotlyFigureProtocolMixin:
+    capabilities: tp.ClassVar[Capability] = _ALL_CAPABILITIES
+    backend_name: tp.ClassVar[str] = 'plotly'
+
+    @property
+    def native(self) -> tp.Any:
+        """Return the underlying native figure object."""
+        return self
+
     def show(self, *args, **kwargs) -> None:
         """Display the figure in PNG format."""
         raise NotImplementedError
@@ -33,8 +115,270 @@ class FigureMixin:
         """Display the figure in SVG format."""
         self.show(renderer="svg", **kwargs)
 
+    def plot_line(self,
+                  x: tp.ArrayLike,
+                  y: tp.ArrayLike,
+                  *,
+                  name: tp.Optional[str] = None,
+                  color: tp.Optional[str] = None,
+                  width: tp.Optional[float] = None,
+                  dash: tp.Optional[str] = None,
+                  opacity: tp.Optional[float] = None,
+                  showlegend: tp.Optional[bool] = None,
+                  row: tp.Optional[int] = None,
+                  col: tp.Optional[int] = None) -> Self:
+        """Plot a line trace via the backend-agnostic protocol."""
+        trace_kwargs: tp.Kwargs = dict(x=x, y=y, mode='lines')
+        if name is not None:
+            trace_kwargs['name'] = name
+        line: tp.Kwargs = {}
+        if color is not None:
+            line['color'] = color
+        if width is not None:
+            line['width'] = width
+        if dash is not None:
+            line['dash'] = dash
+        if line:
+            trace_kwargs['line'] = line
+        if opacity is not None:
+            trace_kwargs['opacity'] = opacity
+        if showlegend is not None:
+            trace_kwargs['showlegend'] = showlegend
+        self.add_trace(go.Scatter(**trace_kwargs), **_add_trace_kwargs(row, col))
+        return self
 
-class Figure(_Figure, FigureMixin):
+    def plot_markers(self,
+                     x: tp.ArrayLike,
+                     y: tp.ArrayLike,
+                     *,
+                     name: tp.Optional[str] = None,
+                     color: tp.Optional[str] = None,
+                     size: tp.Optional[float] = None,
+                     symbol: tp.Optional[str] = None,
+                     line_color: tp.Optional[str] = None,
+                     line_width: tp.Optional[float] = None,
+                     opacity: tp.Optional[float] = None,
+                     showlegend: tp.Optional[bool] = None,
+                     hover_text: tp.Union[str, tp.Sequence[str], None] = None,
+                     row: tp.Optional[int] = None,
+                     col: tp.Optional[int] = None) -> Self:
+        """Plot a marker trace via the backend-agnostic protocol."""
+        trace_kwargs: tp.Kwargs = dict(x=x, y=y, mode='markers')
+        if name is not None:
+            trace_kwargs['name'] = name
+        marker: tp.Kwargs = {}
+        if color is not None:
+            marker['color'] = color
+        if size is not None:
+            marker['size'] = size
+        if symbol is not None:
+            marker['symbol'] = symbol
+        marker_line: tp.Kwargs = {}
+        if line_color is not None:
+            marker_line['color'] = line_color
+        if line_width is not None:
+            marker_line['width'] = line_width
+        if marker_line:
+            marker['line'] = marker_line
+        if marker:
+            trace_kwargs['marker'] = marker
+        if opacity is not None:
+            trace_kwargs['opacity'] = opacity
+        if showlegend is not None:
+            trace_kwargs['showlegend'] = showlegend
+        if hover_text is not None:
+            if isinstance(hover_text, str):
+                n_points = len(x) if hasattr(x, '__len__') else None
+                customdata = [hover_text] * n_points if n_points is not None else [hover_text]
+            else:
+                customdata = list(hover_text)
+            trace_kwargs['customdata'] = customdata
+            trace_kwargs['hovertemplate'] = '%{customdata}<extra></extra>'
+        self.add_trace(go.Scatter(**trace_kwargs), **_add_trace_kwargs(row, col))
+        return self
+
+    def plot_area(self,
+                  x: tp.ArrayLike,
+                  y: tp.ArrayLike,
+                  *,
+                  name: tp.Optional[str] = None,
+                  color: tp.Optional[str] = None,
+                  fillcolor: tp.Optional[str] = None,
+                  showlegend: tp.Optional[bool] = None,
+                  row: tp.Optional[int] = None,
+                  col: tp.Optional[int] = None) -> Self:
+        """Plot a filled-area trace via the backend-agnostic protocol."""
+        trace_kwargs: tp.Kwargs = dict(x=x, y=y, mode='lines', fill='tozeroy')
+        if name is not None:
+            trace_kwargs['name'] = name
+        if color is not None:
+            trace_kwargs['line'] = dict(color=color)
+        if fillcolor is not None:
+            trace_kwargs['fillcolor'] = fillcolor
+        if showlegend is not None:
+            trace_kwargs['showlegend'] = showlegend
+        self.add_trace(go.Scatter(**trace_kwargs), **_add_trace_kwargs(row, col))
+        return self
+
+    def plot_ohlc(self,
+                  x: tp.ArrayLike,
+                  open: tp.ArrayLike,
+                  high: tp.ArrayLike,
+                  low: tp.ArrayLike,
+                  close: tp.ArrayLike,
+                  *,
+                  name: tp.Optional[str] = None,
+                  increasing_color: tp.Optional[str] = None,
+                  decreasing_color: tp.Optional[str] = None,
+                  style: str = 'candlestick',
+                  row: tp.Optional[int] = None,
+                  col: tp.Optional[int] = None) -> Self:
+        """Plot an OHLC chart via the backend-agnostic protocol.
+
+        `style='candlestick'` (default) emits `go.Candlestick`;
+        `style='bars'` emits `go.Ohlc`. Both accept the same
+        `increasing=dict(line=dict(color=...))` / `decreasing=dict(line=dict(color=...))`
+        color threading.
+        """
+        if style == 'candlestick':
+            trace_cls = go.Candlestick
+        elif style == 'bars':
+            trace_cls = go.Ohlc
+        else:
+            raise ValueError(
+                f"plot_ohlc style must be 'candlestick' or 'bars', got {style!r}"
+            )
+        trace_kwargs: tp.Kwargs = dict(x=x, open=open, high=high, low=low, close=close)
+        if name is not None:
+            trace_kwargs['name'] = name
+        if increasing_color is not None:
+            trace_kwargs['increasing'] = dict(line=dict(color=increasing_color))
+        if decreasing_color is not None:
+            trace_kwargs['decreasing'] = dict(line=dict(color=decreasing_color))
+        self.add_trace(trace_cls(**trace_kwargs), **_add_trace_kwargs(row, col))
+        return self
+
+    def plot_histogram(self,
+                       x: tp.ArrayLike,
+                       *,
+                       name: tp.Optional[str] = None,
+                       opacity: tp.Optional[float] = None,
+                       showlegend: tp.Optional[bool] = None,
+                       row: tp.Optional[int] = None,
+                       col: tp.Optional[int] = None) -> Self:
+        """Plot a histogram via the backend-agnostic protocol."""
+        trace_kwargs: tp.Kwargs = dict(x=x)
+        if name is not None:
+            trace_kwargs['name'] = name
+        if opacity is not None:
+            trace_kwargs['opacity'] = opacity
+        if showlegend is not None:
+            trace_kwargs['showlegend'] = showlegend
+        self.add_trace(go.Histogram(**trace_kwargs), **_add_trace_kwargs(row, col))
+        return self
+
+    def plot_bars(self,
+                  x: tp.ArrayLike,
+                  y: tp.ArrayLike,
+                  *,
+                  name: tp.Optional[str] = None,
+                  color: tp.Union[str, tp.ArrayLike, None] = None,
+                  line_width: tp.Optional[float] = None,
+                  opacity: tp.Optional[float] = None,
+                  showlegend: tp.Optional[bool] = None,
+                  row: tp.Optional[int] = None,
+                  col: tp.Optional[int] = None) -> Self:
+        """Plot a bar trace via the backend-agnostic protocol.
+
+        `color` may be a scalar or a sequence (one color per bar). Plotly's
+        `go.Bar` natively dispatches on both. `line_width=0` suppresses the
+        bar border (matching the volume-under-OHLCV convention).
+        """
+        trace_kwargs: tp.Kwargs = dict(x=x, y=y)
+        if name is not None:
+            trace_kwargs['name'] = name
+        marker: tp.Kwargs = {}
+        if color is not None:
+            marker['color'] = color
+        if line_width is not None:
+            marker['line'] = dict(width=line_width)
+        if marker:
+            trace_kwargs['marker'] = marker
+        if opacity is not None:
+            trace_kwargs['opacity'] = opacity
+        if showlegend is not None:
+            trace_kwargs['showlegend'] = showlegend
+        self.add_trace(go.Bar(**trace_kwargs), **_add_trace_kwargs(row, col))
+        return self
+
+    def plot_hline(self,
+                   y: float,
+                   *,
+                   color: tp.Optional[str] = None,
+                   dash: tp.Optional[str] = None,
+                   width: tp.Optional[float] = None,
+                   row: tp.Optional[int] = None,
+                   col: tp.Optional[int] = None) -> Self:
+        """Plot a horizontal line via the backend-agnostic protocol.
+
+        Matches the existing `fig.add_shape(type='line', xref='paper', ...)`
+        pattern used throughout vectorbt (21 call sites), so downstream migration
+        in issues #5/#6 is a byte-identical refactor.
+        """
+        xref, yref = _resolve_subplot_axes(self, row, col)
+        x_domain = get_domain(xref, self)
+        line: tp.Kwargs = {}
+        if color is not None:
+            line['color'] = color
+        if dash is not None:
+            line['dash'] = dash
+        if width is not None:
+            line['width'] = width
+        shape_kwargs: tp.Kwargs = dict(
+            type='line',
+            xref='paper',
+            yref=yref,
+            x0=x_domain[0],
+            x1=x_domain[1],
+            y0=y,
+            y1=y,
+        )
+        if line:
+            shape_kwargs['line'] = line
+        self.add_shape(**shape_kwargs)
+        return self
+
+    def plot_zone(self,
+                  y0: float,
+                  y1: float,
+                  *,
+                  color: tp.Optional[str] = None,
+                  opacity: tp.Optional[float] = None,
+                  row: tp.Optional[int] = None,
+                  col: tp.Optional[int] = None) -> Self:
+        """Plot a horizontal zone (filled rectangle spanning the full x-axis)."""
+        xref, yref = _resolve_subplot_axes(self, row, col)
+        x_domain = get_domain(xref, self)
+        shape_kwargs: tp.Kwargs = dict(
+            type='rect',
+            xref='paper',
+            yref=yref,
+            x0=x_domain[0],
+            x1=x_domain[1],
+            y0=y0,
+            y1=y1,
+            layer='below',
+            line_width=0,
+        )
+        if color is not None:
+            shape_kwargs['fillcolor'] = color
+        if opacity is not None:
+            shape_kwargs['opacity'] = opacity
+        self.add_shape(**shape_kwargs)
+        return self
+
+
+class Figure(_Figure, PlotlyFigureProtocolMixin):
     """Figure."""
 
     def __init__(self, *args, **kwargs) -> None:
@@ -58,7 +402,7 @@ class Figure(_Figure, FigureMixin):
         _Figure.show(self, *args, **show_kwargs)
 
 
-class FigureWidget(_FigureWidget, FigureMixin):
+class FigureWidget(_FigureWidget, PlotlyFigureProtocolMixin):
     """Figure widget."""
 
     def __init__(self, *args, **kwargs) -> None:
@@ -99,3 +443,221 @@ def make_figure(*args, **kwargs) -> tp.BaseFigure:
 def make_subplots(*args, **kwargs) -> tp.BaseFigure:
     """Makes subplots and passes them to `FigureWidget`."""
     return make_figure(_make_subplots(*args, **kwargs))
+
+
+# Subplot-only kwargs accepted by `plotly.subplots.make_subplots`. Used by the
+# router below to detect when the caller wants real subplot semantics even
+# without passing rows/cols explicitly. `figure` is included so that
+# `create_figure(figure=fig)` routes to `make_subplots(figure=fig)` for
+# Plotly's documented populate-existing semantics, rather than falling
+# through to `make_figure`'s positional-figure path.
+_SUBPLOT_ONLY_KWARGS = frozenset({
+    'shared_xaxes', 'shared_yaxes', 'start_cell', 'print_grid',
+    'horizontal_spacing', 'vertical_spacing', 'subplot_titles',
+    'column_widths', 'row_heights', 'specs', 'insets',
+    'column_titles', 'row_titles', 'x_title', 'y_title', 'figure',
+})
+
+BackendFactory = tp.Callable[..., FigureProtocol]
+_BACKEND_REGISTRY: tp.Dict[str, BackendFactory] = {}
+
+
+def register_backend(name: str,
+                     factory: BackendFactory,
+                     *,
+                     override: bool = False) -> None:
+    """Register a plotting backend factory under `name`.
+
+    Not thread-safe; call during application startup.
+    """
+    if not isinstance(name, str) or not name:
+        raise ValueError("backend name must be a non-empty string")
+    if not callable(factory):
+        raise TypeError("factory must be callable")
+    if name in _BACKEND_REGISTRY and not override:
+        raise ValueError(
+            f"backend {name!r} already registered; pass override=True to replace"
+        )
+    _BACKEND_REGISTRY[name] = factory
+
+
+def get_backend(name: str) -> BackendFactory:
+    """Look up a registered plotting backend factory by name."""
+    try:
+        return _BACKEND_REGISTRY[name]
+    except KeyError:
+        raise KeyError(
+            f"unknown plotting backend {name!r}; "
+            f"registered: {sorted(_BACKEND_REGISTRY)}"
+        )
+
+
+def list_backends() -> tp.List[str]:
+    """Return the sorted list of registered plotting backend names."""
+    return sorted(_BACKEND_REGISTRY)
+
+
+def _plotly_factory(*,
+                    rows: tp.Optional[int] = None,
+                    cols: tp.Optional[int] = None,
+                    **kwargs) -> FigureProtocol:
+    """Built-in Plotly backend factory.
+
+    With no `rows`/`cols` and no subplot-only kwargs, delegates to
+    `make_figure()` for byte-identical output. Any explicit `rows`/`cols`
+    (even `rows=1, cols=1`) or any subplot-only kwarg routes to
+    `make_subplots()` so the resulting figure has real subplot metadata.
+    """
+    wants_subplots = (
+        rows is not None
+        or cols is not None
+        or bool(_SUBPLOT_ONLY_KWARGS & kwargs.keys())
+    )
+    if wants_subplots:
+        return make_subplots(
+            rows=1 if rows is None else rows,
+            cols=1 if cols is None else cols,
+            **kwargs,
+        )
+    return make_figure(**kwargs)
+
+
+def create_figure(*,
+                  backend: tp.Optional[str] = None,
+                  rows: tp.Optional[int] = None,
+                  cols: tp.Optional[int] = None,
+                  **kwargs) -> FigureProtocol:
+    """Create a figure via the registered backend factory.
+
+    Keyword-only. `backend=None` reads
+    `settings['plotting']['default_backend']`.
+
+    With no `rows`/`cols` and no subplot-only kwargs, the built-in `'plotly'`
+    backend delegates to `make_figure()` — byte-identical output. Passing
+    explicit `rows`/`cols` (even `rows=1, cols=1`) or any subplot-only kwarg
+    (`specs`, `shared_xaxes`, ...) routes to `make_subplots()` so the
+    resulting figure has real subplot metadata and `get_subplot(...)` works.
+
+    To wrap an already-constructed `plotly.graph_objects.Figure`, use
+    `make_figure(fig)` directly — `create_figure` is keyword-only and has
+    no positional seat for that case.
+
+    Note: only code paths that go through `create_figure` honor
+    `settings['plotting']['default_backend']`. Existing plot methods built
+    on `make_figure` / `make_subplots` (accessors, indicators, the
+    `vbt.plotting.Gauge`/`Scatter`/... helpers, etc.) are unaffected and
+    will be migrated in follow-up issues.
+    """
+    from vectorbt._settings import settings
+    if backend is None:
+        backend = settings['plotting']['default_backend']
+    factory = get_backend(backend)
+    return factory(rows=rows, cols=cols, **kwargs)
+
+
+# ############# Backend resolution helpers ############# #
+
+
+def resolve_backend_for_fig(fig: tp.Any) -> tp.Tuple[str, bool]:
+    """Return `(backend_name, is_plotly)` for an optional figure.
+
+    When `fig is None`, resolves through
+    `settings['plotting']['default_backend']`. When `fig` is a Plotly
+    `BaseFigure`, returns `('plotly', True)`. Otherwise looks up
+    `type(fig).backend_name` (falls back to the class name) — never hardcodes
+    a specific non-Plotly backend name at the registry layer, so future
+    third-party backends get their own name in error messages automatically.
+    """
+    from vectorbt._settings import settings
+    if fig is None:
+        backend = settings['plotting']['default_backend']
+        return (backend, backend == 'plotly')
+    if isinstance(fig, tp.BaseFigure):
+        return ('plotly', True)
+    return (getattr(type(fig), 'backend_name', type(fig).__name__), False)
+
+
+def resolve_backend(
+    fig: tp.Any = None,
+    backend: tp.Optional[str] = None,
+) -> tp.Tuple[str, bool]:
+    """Return `(backend_name, is_plotly)` from an optional figure and/or backend override.
+
+    Precedence:
+    1. If *fig* is not None, detect from the figure object. If *backend*
+       is also provided and conflicts, raise `ValueError`.
+    2. If *fig* is None and *backend* is not None, use *backend* directly.
+    3. If both are None, fall back to
+       ``settings['plotting']['default_backend']``.
+    """
+    if fig is not None:
+        fig_backend, fig_is_plotly = resolve_backend_for_fig(fig)
+        if backend is not None and backend != fig_backend:
+            raise ValueError(
+                f"backend={backend!r} conflicts with the supplied fig, which "
+                f"is a {fig_backend!r} backend figure. Either omit backend= "
+                f"or pass a fig created with backend={backend!r}."
+            )
+        return (fig_backend, fig_is_plotly)
+    if backend is not None:
+        return (backend, backend == 'plotly')
+    # Both None — fall back to global default.
+    return resolve_backend_for_fig(None)
+
+
+def assert_plotly_only_kwargs(is_plotly_backend: bool,
+                              resolved_backend: str,
+                              forcing_kwargs: tp.List[str],
+                              *,
+                              method_name: str) -> None:
+    """Raise `NotImplementedError` if `forcing_kwargs` are used on a non-Plotly backend.
+
+    No-op if `forcing_kwargs` is empty or `is_plotly_backend` is True. The
+    error message mirrors the #5 inline pattern at
+    `vectorbt/ohlcv_accessors.py:389-398` so users see one consistent voice.
+    """
+    if forcing_kwargs and not is_plotly_backend:
+        raise NotImplementedError(
+            f"{method_name} cannot be called with {forcing_kwargs} on the "
+            f"{resolved_backend!r} backend. These parameters are legacy "
+            f"Plotly-specific escape hatches. Prefer first-class protocol "
+            f"kwargs for portable customization, or operate on a Plotly "
+            f"figure directly if you need Plotly-specific styling. To "
+            f"resolve: drop the kwarg, switch to the 'plotly' backend, or "
+            f"construct a Plotly figure yourself and pass it via `fig=`."
+        )
+
+
+def assert_plotly_only_method(is_plotly_backend: bool,
+                              resolved_backend: str,
+                              *,
+                              method_name: str,
+                              reason: str) -> None:
+    """Raise `NotImplementedError` if a permanently-Plotly-only method is called on non-Plotly.
+
+    Used for methods like `plot_against` and `overlay_with_heatmap` whose
+    core behavior has no cross-backend equivalent (not a specific kwarg, the
+    whole method).
+    """
+    if not is_plotly_backend:
+        raise NotImplementedError(
+            f"{method_name} is permanently Plotly-only: {reason} "
+            f"(current backend: {resolved_backend!r}). Switch to the "
+            f"'plotly' backend or construct a Plotly figure yourself and "
+            f"pass it via `fig=`."
+        )
+
+
+def _extract_row_col_routing(add_trace_kwargs: tp.Any) -> tp.Kwargs:
+    """Pull ``row``/``col`` out of *add_trace_kwargs* for forwarding to protocol methods."""
+    if not add_trace_kwargs:
+        return {}
+    routing: tp.Kwargs = {}
+    if 'row' in add_trace_kwargs:
+        routing['row'] = add_trace_kwargs['row']
+    if 'col' in add_trace_kwargs:
+        routing['col'] = add_trace_kwargs['col']
+    return routing
+
+
+register_backend('plotly', _plotly_factory)

--- a/vectorbt/utils/figure.py
+++ b/vectorbt/utils/figure.py
@@ -96,7 +96,7 @@ def _add_trace_kwargs(row: tp.Optional[int],
 
 class PlotlyFigureProtocolMixin:
     capabilities: tp.ClassVar[Capability] = _ALL_CAPABILITIES
-    backend_name: tp.ClassVar[str] = 'plotly'
+    renderer_name: tp.ClassVar[str] = 'plotly'
 
     @property
     def native(self) -> tp.Any:
@@ -127,7 +127,7 @@ class PlotlyFigureProtocolMixin:
                   showlegend: tp.Optional[bool] = None,
                   row: tp.Optional[int] = None,
                   col: tp.Optional[int] = None) -> Self:
-        """Plot a line trace via the backend-agnostic protocol."""
+        """Plot a line trace via the renderer-agnostic protocol."""
         trace_kwargs: tp.Kwargs = dict(x=x, y=y, mode='lines')
         if name is not None:
             trace_kwargs['name'] = name
@@ -162,7 +162,7 @@ class PlotlyFigureProtocolMixin:
                      hover_text: tp.Union[str, tp.Sequence[str], None] = None,
                      row: tp.Optional[int] = None,
                      col: tp.Optional[int] = None) -> Self:
-        """Plot a marker trace via the backend-agnostic protocol."""
+        """Plot a marker trace via the renderer-agnostic protocol."""
         trace_kwargs: tp.Kwargs = dict(x=x, y=y, mode='markers')
         if name is not None:
             trace_kwargs['name'] = name
@@ -213,7 +213,7 @@ class PlotlyFigureProtocolMixin:
                   showlegend: tp.Optional[bool] = None,
                   row: tp.Optional[int] = None,
                   col: tp.Optional[int] = None) -> Self:
-        """Plot a filled-area trace via the backend-agnostic protocol."""
+        """Plot a filled-area trace via the renderer-agnostic protocol."""
         trace_kwargs: tp.Kwargs = dict(x=x, y=y, mode='lines', fill='tozeroy')
         if name is not None:
             trace_kwargs['name'] = name
@@ -239,7 +239,7 @@ class PlotlyFigureProtocolMixin:
                   style: str = 'candlestick',
                   row: tp.Optional[int] = None,
                   col: tp.Optional[int] = None) -> Self:
-        """Plot an OHLC chart via the backend-agnostic protocol.
+        """Plot an OHLC chart via the renderer-agnostic protocol.
 
         `style='candlestick'` (default) emits `go.Candlestick`;
         `style='bars'` emits `go.Ohlc`. Both accept the same
@@ -272,7 +272,7 @@ class PlotlyFigureProtocolMixin:
                        showlegend: tp.Optional[bool] = None,
                        row: tp.Optional[int] = None,
                        col: tp.Optional[int] = None) -> Self:
-        """Plot a histogram via the backend-agnostic protocol."""
+        """Plot a histogram via the renderer-agnostic protocol."""
         trace_kwargs: tp.Kwargs = dict(x=x)
         if name is not None:
             trace_kwargs['name'] = name
@@ -294,7 +294,7 @@ class PlotlyFigureProtocolMixin:
                   showlegend: tp.Optional[bool] = None,
                   row: tp.Optional[int] = None,
                   col: tp.Optional[int] = None) -> Self:
-        """Plot a bar trace via the backend-agnostic protocol.
+        """Plot a bar trace via the renderer-agnostic protocol.
 
         `color` may be a scalar or a sequence (one color per bar). Plotly's
         `go.Bar` natively dispatches on both. `line_width=0` suppresses the
@@ -325,7 +325,7 @@ class PlotlyFigureProtocolMixin:
                    width: tp.Optional[float] = None,
                    row: tp.Optional[int] = None,
                    col: tp.Optional[int] = None) -> Self:
-        """Plot a horizontal line via the backend-agnostic protocol.
+        """Plot a horizontal line via the renderer-agnostic protocol.
 
         Matches the existing `fig.add_shape(type='line', xref='paper', ...)`
         pattern used throughout vectorbt (21 call sites), so downstream migration
@@ -464,50 +464,50 @@ _SUBPLOT_ONLY_KWARGS = frozenset({
     'column_titles', 'row_titles', 'x_title', 'y_title', 'figure',
 })
 
-BackendFactory = tp.Callable[..., FigureProtocol]
-_BACKEND_REGISTRY: tp.Dict[str, BackendFactory] = {}
+RendererFactory = tp.Callable[..., FigureProtocol]
+_RENDERER_REGISTRY: tp.Dict[str, RendererFactory] = {}
 
 
-def register_backend(name: str,
-                     factory: BackendFactory,
-                     *,
-                     override: bool = False) -> None:
-    """Register a plotting backend factory under `name`.
+def register_renderer(name: str,
+                      factory: RendererFactory,
+                      *,
+                      override: bool = False) -> None:
+    """Register a plotting renderer factory under `name`.
 
     Not thread-safe; call during application startup.
     """
     if not isinstance(name, str) or not name:
-        raise ValueError("backend name must be a non-empty string")
+        raise ValueError("renderer name must be a non-empty string")
     if not callable(factory):
         raise TypeError("factory must be callable")
-    if name in _BACKEND_REGISTRY and not override:
+    if name in _RENDERER_REGISTRY and not override:
         raise ValueError(
-            f"backend {name!r} already registered; pass override=True to replace"
+            f"renderer {name!r} already registered; pass override=True to replace"
         )
-    _BACKEND_REGISTRY[name] = factory
+    _RENDERER_REGISTRY[name] = factory
 
 
-def get_backend(name: str) -> BackendFactory:
-    """Look up a registered plotting backend factory by name."""
+def get_renderer(name: str) -> RendererFactory:
+    """Look up a registered plotting renderer factory by name."""
     try:
-        return _BACKEND_REGISTRY[name]
+        return _RENDERER_REGISTRY[name]
     except KeyError:
         raise KeyError(
-            f"unknown plotting backend {name!r}; "
-            f"registered: {sorted(_BACKEND_REGISTRY)}"
+            f"unknown plotting renderer {name!r}; "
+            f"registered: {sorted(_RENDERER_REGISTRY)}"
         )
 
 
-def list_backends() -> tp.List[str]:
-    """Return the sorted list of registered plotting backend names."""
-    return sorted(_BACKEND_REGISTRY)
+def list_renderers() -> tp.List[str]:
+    """Return the sorted list of registered plotting renderer names."""
+    return sorted(_RENDERER_REGISTRY)
 
 
 def _plotly_factory(*,
                     rows: tp.Optional[int] = None,
                     cols: tp.Optional[int] = None,
                     **kwargs) -> FigureProtocol:
-    """Built-in Plotly backend factory.
+    """Built-in Plotly renderer factory.
 
     With no `rows`/`cols` and no subplot-only kwargs, delegates to
     `make_figure()` for byte-identical output. Any explicit `rows`/`cols`
@@ -529,17 +529,23 @@ def _plotly_factory(*,
 
 
 def create_figure(*,
-                  backend: tp.Optional[str] = None,
+                  renderer: tp.Optional[str] = None,
                   rows: tp.Optional[int] = None,
                   cols: tp.Optional[int] = None,
                   **kwargs) -> FigureProtocol:
-    """Create a figure via the registered backend factory.
+    """Create a figure via the registered renderer factory.
 
-    Keyword-only. `backend=None` reads
-    `settings['plotting']['default_backend']`.
+    Keyword-only. `renderer=None` reads
+    `settings['plotting']['default_renderer']`.
+
+    Note: vectorbt's `renderer=` selects the *plotting library* (e.g.
+    `'plotly'`, `'lightweight_charts'`) that produces the figure. This is
+    distinct from Plotly's own `fig.show(renderer=...)` kwarg, which selects
+    an *output format* (`'png'`, `'svg'`, `'browser'`, ...) when displaying
+    a Plotly figure.
 
     With no `rows`/`cols` and no subplot-only kwargs, the built-in `'plotly'`
-    backend delegates to `make_figure()` — byte-identical output. Passing
+    renderer delegates to `make_figure()` — byte-identical output. Passing
     explicit `rows`/`cols` (even `rows=1, cols=1`) or any subplot-only kwarg
     (`specs`, `shared_xaxes`, ...) routes to `make_subplots()` so the
     resulting figure has real subplot metadata and `get_subplot(...)` works.
@@ -549,107 +555,107 @@ def create_figure(*,
     no positional seat for that case.
 
     Note: only code paths that go through `create_figure` honor
-    `settings['plotting']['default_backend']`. Existing plot methods built
+    `settings['plotting']['default_renderer']`. Existing plot methods built
     on `make_figure` / `make_subplots` (accessors, indicators, the
     `vbt.plotting.Gauge`/`Scatter`/... helpers, etc.) are unaffected and
     will be migrated in follow-up issues.
     """
     from vectorbt._settings import settings
-    if backend is None:
-        backend = settings['plotting']['default_backend']
-    factory = get_backend(backend)
+    if renderer is None:
+        renderer = settings['plotting']['default_renderer']
+    factory = get_renderer(renderer)
     return factory(rows=rows, cols=cols, **kwargs)
 
 
-# ############# Backend resolution helpers ############# #
+# ############# Renderer resolution helpers ############# #
 
 
-def resolve_backend_for_fig(fig: tp.Any) -> tp.Tuple[str, bool]:
-    """Return `(backend_name, is_plotly)` for an optional figure.
+def resolve_renderer_for_fig(fig: tp.Any) -> tp.Tuple[str, bool]:
+    """Return `(renderer_name, is_plotly)` for an optional figure.
 
     When `fig is None`, resolves through
-    `settings['plotting']['default_backend']`. When `fig` is a Plotly
+    `settings['plotting']['default_renderer']`. When `fig` is a Plotly
     `BaseFigure`, returns `('plotly', True)`. Otherwise looks up
-    `type(fig).backend_name` (falls back to the class name) — never hardcodes
-    a specific non-Plotly backend name at the registry layer, so future
-    third-party backends get their own name in error messages automatically.
+    `type(fig).renderer_name` (falls back to the class name) — never hardcodes
+    a specific non-Plotly renderer name at the registry layer, so future
+    third-party renderers get their own name in error messages automatically.
     """
     from vectorbt._settings import settings
     if fig is None:
-        backend = settings['plotting']['default_backend']
-        return (backend, backend == 'plotly')
+        renderer = settings['plotting']['default_renderer']
+        return (renderer, renderer == 'plotly')
     if isinstance(fig, tp.BaseFigure):
         return ('plotly', True)
-    return (getattr(type(fig), 'backend_name', type(fig).__name__), False)
+    return (getattr(type(fig), 'renderer_name', type(fig).__name__), False)
 
 
-def resolve_backend(
+def resolve_renderer(
     fig: tp.Any = None,
-    backend: tp.Optional[str] = None,
+    renderer: tp.Optional[str] = None,
 ) -> tp.Tuple[str, bool]:
-    """Return `(backend_name, is_plotly)` from an optional figure and/or backend override.
+    """Return `(renderer_name, is_plotly)` from an optional figure and/or renderer override.
 
     Precedence:
-    1. If *fig* is not None, detect from the figure object. If *backend*
+    1. If *fig* is not None, detect from the figure object. If *renderer*
        is also provided and conflicts, raise `ValueError`.
-    2. If *fig* is None and *backend* is not None, use *backend* directly.
+    2. If *fig* is None and *renderer* is not None, use *renderer* directly.
     3. If both are None, fall back to
-       ``settings['plotting']['default_backend']``.
+       ``settings['plotting']['default_renderer']``.
     """
     if fig is not None:
-        fig_backend, fig_is_plotly = resolve_backend_for_fig(fig)
-        if backend is not None and backend != fig_backend:
+        fig_renderer, fig_is_plotly = resolve_renderer_for_fig(fig)
+        if renderer is not None and renderer != fig_renderer:
             raise ValueError(
-                f"backend={backend!r} conflicts with the supplied fig, which "
-                f"is a {fig_backend!r} backend figure. Either omit backend= "
-                f"or pass a fig created with backend={backend!r}."
+                f"renderer={renderer!r} conflicts with the supplied fig, which "
+                f"is a {fig_renderer!r} renderer figure. Either omit renderer= "
+                f"or pass a fig created with renderer={renderer!r}."
             )
-        return (fig_backend, fig_is_plotly)
-    if backend is not None:
-        return (backend, backend == 'plotly')
+        return (fig_renderer, fig_is_plotly)
+    if renderer is not None:
+        return (renderer, renderer == 'plotly')
     # Both None — fall back to global default.
-    return resolve_backend_for_fig(None)
+    return resolve_renderer_for_fig(None)
 
 
-def assert_plotly_only_kwargs(is_plotly_backend: bool,
-                              resolved_backend: str,
+def assert_plotly_only_kwargs(is_plotly_renderer: bool,
+                              resolved_renderer: str,
                               forcing_kwargs: tp.List[str],
                               *,
                               method_name: str) -> None:
-    """Raise `NotImplementedError` if `forcing_kwargs` are used on a non-Plotly backend.
+    """Raise `NotImplementedError` if `forcing_kwargs` are used on a non-Plotly renderer.
 
-    No-op if `forcing_kwargs` is empty or `is_plotly_backend` is True. The
+    No-op if `forcing_kwargs` is empty or `is_plotly_renderer` is True. The
     error message mirrors the #5 inline pattern at
     `vectorbt/ohlcv_accessors.py:389-398` so users see one consistent voice.
     """
-    if forcing_kwargs and not is_plotly_backend:
+    if forcing_kwargs and not is_plotly_renderer:
         raise NotImplementedError(
             f"{method_name} cannot be called with {forcing_kwargs} on the "
-            f"{resolved_backend!r} backend. These parameters are legacy "
+            f"{resolved_renderer!r} renderer. These parameters are legacy "
             f"Plotly-specific escape hatches. Prefer first-class protocol "
             f"kwargs for portable customization, or operate on a Plotly "
             f"figure directly if you need Plotly-specific styling. To "
-            f"resolve: drop the kwarg, switch to the 'plotly' backend, or "
+            f"resolve: drop the kwarg, switch to the 'plotly' renderer, or "
             f"construct a Plotly figure yourself and pass it via `fig=`."
         )
 
 
-def assert_plotly_only_method(is_plotly_backend: bool,
-                              resolved_backend: str,
+def assert_plotly_only_method(is_plotly_renderer: bool,
+                              resolved_renderer: str,
                               *,
                               method_name: str,
                               reason: str) -> None:
     """Raise `NotImplementedError` if a permanently-Plotly-only method is called on non-Plotly.
 
     Used for methods like `plot_against` and `overlay_with_heatmap` whose
-    core behavior has no cross-backend equivalent (not a specific kwarg, the
+    core behavior has no cross-renderer equivalent (not a specific kwarg, the
     whole method).
     """
-    if not is_plotly_backend:
+    if not is_plotly_renderer:
         raise NotImplementedError(
             f"{method_name} is permanently Plotly-only: {reason} "
-            f"(current backend: {resolved_backend!r}). Switch to the "
-            f"'plotly' backend or construct a Plotly figure yourself and "
+            f"(current renderer: {resolved_renderer!r}). Switch to the "
+            f"'plotly' renderer or construct a Plotly figure yourself and "
             f"pass it via `fig=`."
         )
 
@@ -666,4 +672,4 @@ def _extract_row_col_routing(add_trace_kwargs: tp.Any) -> tp.Kwargs:
     return routing
 
 
-register_backend('plotly', _plotly_factory)
+register_renderer('plotly', _plotly_factory)

--- a/vectorbt/utils/plotting_protocol.py
+++ b/vectorbt/utils/plotting_protocol.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Oleg Polakow. All rights reserved.
 # This code is licensed under Apache 2.0 with Commons Clause license (see LICENSE.md for details)
 
-"""Backend-agnostic figure protocol and capability flags."""
+"""Renderer-agnostic figure protocol and capability flags."""
 
 import enum
 
@@ -19,7 +19,7 @@ from vectorbt import _typing as tp
 
 
 class Capability(enum.Flag):
-    """Capability flags declaring which chart types a figure backend supports."""
+    """Capability flags declaring which chart types a figure renderer supports."""
 
     TIME_SERIES = enum.auto()
     OHLC = enum.auto()
@@ -39,10 +39,10 @@ class Capability(enum.Flag):
 
 @runtime_checkable
 class FigureProtocol(Protocol):
-    """Backend-agnostic figure interface."""
+    """Renderer-agnostic figure interface."""
 
     capabilities: tp.ClassVar[Capability]
-    backend_name: tp.ClassVar[str]
+    renderer_name: tp.ClassVar[str]
 
     @property
     def native(self) -> tp.Any:
@@ -62,7 +62,7 @@ class FigureProtocol(Protocol):
         row: tp.Optional[int] = None,
         col: tp.Optional[int] = None,
     ) -> Self:
-        """Plot a line trace via the backend-agnostic protocol."""
+        """Plot a line trace via the renderer-agnostic protocol."""
 
     def plot_markers(
         self,
@@ -81,7 +81,7 @@ class FigureProtocol(Protocol):
         row: tp.Optional[int] = None,
         col: tp.Optional[int] = None,
     ) -> Self:
-        """Plot a marker trace via the backend-agnostic protocol.
+        """Plot a marker trace via the renderer-agnostic protocol.
 
         `line_color` and `line_width` style the marker border. Plotly maps
         them to `marker.line.color` / `marker.line.width`. LWC's
@@ -112,7 +112,7 @@ class FigureProtocol(Protocol):
         row: tp.Optional[int] = None,
         col: tp.Optional[int] = None,
     ) -> Self:
-        """Plot an OHLC chart via the backend-agnostic protocol.
+        """Plot an OHLC chart via the renderer-agnostic protocol.
 
         `style` selects the visualization:
 
@@ -120,7 +120,7 @@ class FigureProtocol(Protocol):
           emits `go.Candlestick`; LWC emits `CandlestickSeries`.
         - `'bars'`: tick-style OHLC bars (thin vertical line per period with
           open/close ticks on either side). Plotly emits `go.Ohlc`; LWC emits
-          `BarSeries`. Both backends support this natively.
+          `BarSeries`. Both renderers support this natively.
 
         Unknown `style` values raise `ValueError`.
         """
@@ -135,7 +135,7 @@ class FigureProtocol(Protocol):
         row: tp.Optional[int] = None,
         col: tp.Optional[int] = None,
     ) -> Self:
-        """Plot a histogram via the backend-agnostic protocol."""
+        """Plot a histogram via the renderer-agnostic protocol."""
 
     def plot_bars(
         self,
@@ -150,7 +150,7 @@ class FigureProtocol(Protocol):
         row: tp.Optional[int] = None,
         col: tp.Optional[int] = None,
     ) -> Self:
-        """Plot a bar trace via the backend-agnostic protocol.
+        """Plot a bar trace via the renderer-agnostic protocol.
 
         `color` accepts either a single color string or a sequence of per-bar
         colors (one per data point). Plotly's `go.Bar` natively dispatches on
@@ -199,7 +199,7 @@ class FigureProtocol(Protocol):
         row: tp.Optional[int] = None,
         col: tp.Optional[int] = None,
     ) -> Self:
-        """Plot a filled area trace via the backend-agnostic protocol."""
+        """Plot a filled area trace via the renderer-agnostic protocol."""
 
     def show(self, *args: tp.Any, **kwargs: tp.Any) -> None:
         """Display the figure."""

--- a/vectorbt/utils/plotting_protocol.py
+++ b/vectorbt/utils/plotting_protocol.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2021 Oleg Polakow. All rights reserved.
+# This code is licensed under Apache 2.0 with Commons Clause license (see LICENSE.md for details)
+
+"""Backend-agnostic figure protocol and capability flags."""
+
+import enum
+
+try:
+    from typing import Protocol, runtime_checkable
+except ImportError:
+    from typing_extensions import Protocol, runtime_checkable
+
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
+
+from vectorbt import _typing as tp
+
+
+class Capability(enum.Flag):
+    """Capability flags declaring which chart types a figure backend supports."""
+
+    TIME_SERIES = enum.auto()
+    OHLC = enum.auto()
+    LINE = enum.auto()
+    AREA = enum.auto()
+    HISTOGRAM = enum.auto()
+    BAR = enum.auto()
+    MARKERS = enum.auto()
+    HLINE = enum.auto()
+    ZONE = enum.auto()
+    GAUGE = enum.auto()
+    HEATMAP = enum.auto()
+    BOX = enum.auto()
+    SCATTER_XY = enum.auto()
+    VOLUME_3D = enum.auto()
+
+
+@runtime_checkable
+class FigureProtocol(Protocol):
+    """Backend-agnostic figure interface."""
+
+    capabilities: tp.ClassVar[Capability]
+    backend_name: tp.ClassVar[str]
+
+    @property
+    def native(self) -> tp.Any:
+        """Return the underlying native figure object."""
+
+    def plot_line(
+        self,
+        x: tp.ArrayLike,
+        y: tp.ArrayLike,
+        *,
+        name: tp.Optional[str] = None,
+        color: tp.Optional[str] = None,
+        width: tp.Optional[float] = None,
+        dash: tp.Optional[str] = None,
+        opacity: tp.Optional[float] = None,
+        showlegend: tp.Optional[bool] = None,
+        row: tp.Optional[int] = None,
+        col: tp.Optional[int] = None,
+    ) -> Self:
+        """Plot a line trace via the backend-agnostic protocol."""
+
+    def plot_markers(
+        self,
+        x: tp.ArrayLike,
+        y: tp.ArrayLike,
+        *,
+        name: tp.Optional[str] = None,
+        color: tp.Optional[str] = None,
+        size: tp.Optional[float] = None,
+        symbol: tp.Optional[str] = None,
+        line_color: tp.Optional[str] = None,
+        line_width: tp.Optional[float] = None,
+        opacity: tp.Optional[float] = None,
+        showlegend: tp.Optional[bool] = None,
+        hover_text: tp.Union[str, tp.Sequence[str], None] = None,
+        row: tp.Optional[int] = None,
+        col: tp.Optional[int] = None,
+    ) -> Self:
+        """Plot a marker trace via the backend-agnostic protocol.
+
+        `line_color` and `line_width` style the marker border. Plotly maps
+        them to `marker.line.color` / `marker.line.width`. LWC's
+        `createSeriesMarkers` has no marker-border concept and accepts these
+        parameters as no-ops for protocol parity (matching the
+        `plot_bars.line_width` precedent).
+
+        `hover_text` supplies per-marker annotation strings. A scalar string
+        applies to every marker; a sequence must match the number of points.
+        Plotly maps this to `customdata` + `hovertemplate='%{customdata}<extra></extra>'`
+        so hovering a marker shows the string as a tooltip. LWC maps each
+        string to the per-marker `tooltip.title` field consumed by litecharts'
+        `marker_tooltips` plugin (rendered as a hover popup on the chart).
+        """
+
+    def plot_ohlc(
+        self,
+        x: tp.ArrayLike,
+        open: tp.ArrayLike,
+        high: tp.ArrayLike,
+        low: tp.ArrayLike,
+        close: tp.ArrayLike,
+        *,
+        name: tp.Optional[str] = None,
+        increasing_color: tp.Optional[str] = None,
+        decreasing_color: tp.Optional[str] = None,
+        style: str = 'candlestick',
+        row: tp.Optional[int] = None,
+        col: tp.Optional[int] = None,
+    ) -> Self:
+        """Plot an OHLC chart via the backend-agnostic protocol.
+
+        `style` selects the visualization:
+
+        - `'candlestick'` (default): filled candle bodies with wicks. Plotly
+          emits `go.Candlestick`; LWC emits `CandlestickSeries`.
+        - `'bars'`: tick-style OHLC bars (thin vertical line per period with
+          open/close ticks on either side). Plotly emits `go.Ohlc`; LWC emits
+          `BarSeries`. Both backends support this natively.
+
+        Unknown `style` values raise `ValueError`.
+        """
+
+    def plot_histogram(
+        self,
+        x: tp.ArrayLike,
+        *,
+        name: tp.Optional[str] = None,
+        opacity: tp.Optional[float] = None,
+        showlegend: tp.Optional[bool] = None,
+        row: tp.Optional[int] = None,
+        col: tp.Optional[int] = None,
+    ) -> Self:
+        """Plot a histogram via the backend-agnostic protocol."""
+
+    def plot_bars(
+        self,
+        x: tp.ArrayLike,
+        y: tp.ArrayLike,
+        *,
+        name: tp.Optional[str] = None,
+        color: tp.Union[str, tp.ArrayLike, None] = None,
+        line_width: tp.Optional[float] = None,
+        opacity: tp.Optional[float] = None,
+        showlegend: tp.Optional[bool] = None,
+        row: tp.Optional[int] = None,
+        col: tp.Optional[int] = None,
+    ) -> Self:
+        """Plot a bar trace via the backend-agnostic protocol.
+
+        `color` accepts either a single color string or a sequence of per-bar
+        colors (one per data point). Plotly's `go.Bar` natively dispatches on
+        both shapes; LWC injects per-datapoint colors into the `HistogramSeries`
+        data dicts.
+
+        `line_width` controls the bar border width. Pass `0` to suppress the
+        border entirely (the convention used by volume panes on OHLCV charts).
+        LWC's `HistogramSeries` has no bar-border concept and accepts this
+        parameter as a no-op for protocol parity.
+        """
+
+    def plot_hline(
+        self,
+        y: float,
+        *,
+        color: tp.Optional[str] = None,
+        dash: tp.Optional[str] = None,
+        width: tp.Optional[float] = None,
+        row: tp.Optional[int] = None,
+        col: tp.Optional[int] = None,
+    ) -> Self:
+        """Plot a horizontal line spanning the plot or a specific subplot."""
+
+    def plot_zone(
+        self,
+        y0: float,
+        y1: float,
+        *,
+        color: tp.Optional[str] = None,
+        opacity: tp.Optional[float] = None,
+        row: tp.Optional[int] = None,
+        col: tp.Optional[int] = None,
+    ) -> Self:
+        """Plot a horizontal zone (filled rectangle spanning the full x-axis)."""
+
+    def plot_area(
+        self,
+        x: tp.ArrayLike,
+        y: tp.ArrayLike,
+        *,
+        name: tp.Optional[str] = None,
+        color: tp.Optional[str] = None,
+        fillcolor: tp.Optional[str] = None,
+        showlegend: tp.Optional[bool] = None,
+        row: tp.Optional[int] = None,
+        col: tp.Optional[int] = None,
+    ) -> Self:
+        """Plot a filled area trace via the backend-agnostic protocol."""
+
+    def show(self, *args: tp.Any, **kwargs: tp.Any) -> None:
+        """Display the figure."""
+
+    def to_html(self, *args: tp.Any, **kwargs: tp.Any) -> str:
+        """Render the figure as an HTML string."""


### PR DESCRIPTION
As progress towards https://github.com/polakowo/vectorbt/issues/815, this PR introduces a new Protocol, FigureProtocol, which lays out the contract that any plotting backend should fulfill.

In this PR I have focused on creating the protocol itself as well as adding PlotlyFigureProtocolMixin, which implements the FigureProtocol for plotly specifically. This is purely additive, no user facing changes.

We also setup the machinery for plugging in new backends later with a registry.

Next steps would be migrating internal callers to use the protocol as opposed to direct plotly calls where possible, which will help refine the design of the protocol before adding lightweight charts support