### PR TITLE
Fix Data.get for unnamed multi-symbol series

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -840,6 +840,27 @@ class TestData:
                 columns=pd.Index([0, 1], dtype="int64", name="symbol"),
             ),
         )
+
+        class UnnamedSeriesData(vbt.Data):
+            @classmethod
+            def download_symbol(cls, symbol):
+                return pd.Series(
+                    [1.0, 2.0, 3.0],
+                    index=pd.date_range("2021-01-01", "2021-01-03"),
+                )
+
+        pd.testing.assert_series_equal(
+            UnnamedSeriesData.download(["RANDNX1", "RANDNX2"]).get(column="RANDNX1"),
+            pd.Series(
+                [1.0, 2.0, 3.0],
+                index=pd.DatetimeIndex(
+                    ["2021-01-01 00:00:00", "2021-01-02 00:00:00", "2021-01-03 00:00:00"],
+                    freq="D",
+                    tz=timezone.utc,
+                ),
+                name="RANDNX1",
+            ),
+        )
         pd.testing.assert_frame_equal(
             MyData.download([0, 1], shape=(5, 3), columns=["feat0", "feat1", "feat2"]).get("feat0"),
             pd.DataFrame(

--- a/vectorbt/data/base.py
+++ b/vectorbt/data/base.py
@@ -706,7 +706,14 @@ class Data(Wrapping, StatsBuilderMixin, PlotsBuilderMixin, metaclass=MetaData):
 
         concat_data = self.concat(**kwargs)
         if len(concat_data) == 1:
-            return tuple(concat_data.values())[0]
+            single_data = tuple(concat_data.values())[0]
+            if column is not None:
+                if isinstance(column, list):
+                    if isinstance(single_data, pd.DataFrame) and all(c in single_data.columns for c in column):
+                        return single_data[column]
+                elif isinstance(single_data, pd.DataFrame) and column in single_data.columns:
+                    return single_data[column]
+            return single_data
         if column is not None:
             if isinstance(column, list):
                 return tuple([concat_data[c] for c in column])


### PR DESCRIPTION
## Summary
- let `Data.get(column=...)` select a symbol column when multi-symbol unnamed Series data concatenates to a single DataFrame
- preserve the existing default `get()` behavior for single-field multi-symbol data
- add a regression test for issue #840

Closes #840.

## Validation
- `python -m pytest tests\test_data.py::TestData::test_get -q`
- `python -m pytest tests\test_data.py::TestData::test_concat tests\test_data.py::TestData::test_get -q`
- `git diff --check`