### PR TITLE
Fix custom benchmark plotting for selected portfolio columns

### DIFF
--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1220,9 +1220,7 @@ class TestPortfolioPlotSmoke:
         assert "Value" in nt
         assert isinstance(nt["Value"], go.Scatter)
         assert len(nt["Value"].y) == len(index_5)
-
-    def test_plot_cum_returns_accepts_custom_benchmark_for_selected_column(self):
-        """Custom benchmark returns should work when plotting a selected portfolio column."""
+        # Custom benchmark returns should also work when plotting a selected portfolio column.
         fig = pf_multi.plot_cum_returns(column="a", benchmark_rets=pf_multi["b"].returns())
         nt = named_traces(fig)
         assert "Benchmark" in nt

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1221,6 +1221,14 @@ class TestPortfolioPlotSmoke:
         assert isinstance(nt["Value"], go.Scatter)
         assert len(nt["Value"].y) == len(index_5)
 
+    def test_plot_cum_returns_accepts_custom_benchmark_for_selected_column(self):
+        """Custom benchmark returns should work when plotting a selected portfolio column."""
+        fig = pf_multi.plot_cum_returns(column="a", benchmark_rets=pf_multi["b"].returns())
+        nt = named_traces(fig)
+        assert "Benchmark" in nt
+        assert isinstance(nt["Benchmark"], go.Scatter)
+        assert len(nt["Benchmark"].y) == len(index_5)
+
     def test_smoke_plot_drawdowns(self):
         self._assert_fig(
             pf_multi.plot_drawdowns(column="a"),

--- a/vectorbt/portfolio/base.py
+++ b/vectorbt/portfolio/base.py
@@ -5385,7 +5385,7 @@ class Portfolio(Wrapping, StatsBuilderMixin, PlotsBuilderMixin, metaclass=MetaPo
         if benchmark_rets is None:
             benchmark_rets = self.benchmark_returns(group_by=group_by)
         else:
-            benchmark_rets = broadcast_to(benchmark_rets, self.obj)
+            benchmark_rets = broadcast_to(benchmark_rets, self.wrapper.dummy(group_by=group_by))
         benchmark_rets = self.select_one_from_obj(benchmark_rets, self.wrapper.regroup(group_by), column=column)
         kwargs = merge_dicts(
             dict(


### PR DESCRIPTION
Fixes #726.

`plot_cum_returns()` handled a custom `benchmark_rets` input by broadcasting it against `self.obj`, but `Portfolio` doesn't have that attribute. That raises an `AttributeError` as soon as you pass custom benchmark returns while plotting a selected column.

I changed the broadcast target to `self.wrapper.dummy(group_by=group_by)`, which matches the portfolio shape the method is about to select from. I also added a regression test that exercises `pf_multi.plot_cum_returns(column="a", benchmark_rets=pf_multi["b"].returns())`.

Verified with:
- `python -m pytest tests/test_plotting.py -k "cum_returns"`
- direct repro script from the issue now returns successfully instead of raising `AttributeError`
