### PR TITLE
Fix NaN-aware top/bottom N parity across engines

### DIFF
--- a/rust/src/records.rs
+++ b/rust/src/records.rs
@@ -651,19 +651,90 @@ fn top_n_mapped_mask(mapped_arr: &[f64], col_idxs: &[i64], col_lens: &[i64], n: 
             continue;
         }
         let col_start_idx = col_start_idxs[col];
-
-        // Collect (value, global_index) for this column
-        let mut items: Vec<(f64, usize)> = Vec::with_capacity(col_len);
-        for k in 0..col_len {
-            let global_idx = col_idxs[col_start_idx + k] as usize;
-            items.push((mapped_arr[global_idx], global_idx));
+        if n >= col_len {
+            for k in 0..col_len {
+                let global_idx = col_idxs[col_start_idx + k] as usize;
+                out[global_idx] = true;
+            }
+            continue;
+        }
+        if n == 0 {
+            continue;
         }
 
-        // Sort ascending; top N = last N after sort
-        items.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
-        let start = if col_len > n { col_len - n } else { 0 };
-        for k in start..col_len {
-            out[items[k].1] = true;
+        // Collect non-NaN values for partitioning
+        let mut valid_values: Vec<f64> = Vec::with_capacity(col_len);
+        for k in 0..col_len {
+            let global_idx = col_idxs[col_start_idx + k] as usize;
+            let value = mapped_arr[global_idx];
+            if !value.is_nan() {
+                valid_values.push(value);
+            }
+        }
+
+        let n_valid = valid_values.len();
+        if n_valid == 0 {
+            let mut n_remaining = n;
+            for k in (0..col_len).rev() {
+                let global_idx = col_idxs[col_start_idx + k] as usize;
+                out[global_idx] = true;
+                n_remaining -= 1;
+                if n_remaining == 0 {
+                    break;
+                }
+            }
+            continue;
+        }
+
+        if n > n_valid {
+            for k in 0..col_len {
+                let global_idx = col_idxs[col_start_idx + k] as usize;
+                if !mapped_arr[global_idx].is_nan() {
+                    out[global_idx] = true;
+                }
+            }
+            let mut n_remaining = n - n_valid;
+            for k in (0..col_len).rev() {
+                let global_idx = col_idxs[col_start_idx + k] as usize;
+                if mapped_arr[global_idx].is_nan() {
+                    out[global_idx] = true;
+                    n_remaining -= 1;
+                    if n_remaining == 0 {
+                        break;
+                    }
+                }
+            }
+            continue;
+        }
+
+        let n_partition = n_valid - n;
+        valid_values.select_nth_unstable_by(n_partition, |a, b| a.partial_cmp(b).unwrap());
+        let pivot = valid_values[n_partition];
+
+        let mut n_greater = 0usize;
+        for k in 0..col_len {
+            let global_idx = col_idxs[col_start_idx + k] as usize;
+            let value = mapped_arr[global_idx];
+            if !value.is_nan() && value > pivot {
+                out[global_idx] = true;
+                n_greater += 1;
+            }
+        }
+
+        let mut n_remaining = n - n_greater;
+        if n_remaining == 0 {
+            continue;
+        }
+        for k in (0..col_len).rev() {
+            let global_idx = col_idxs[col_start_idx + k] as usize;
+            let value = mapped_arr[global_idx];
+            if !value.is_nan() && value == pivot {
+                out[global_idx] = true;
+                n_remaining -= 1;
+                if n_remaining == 0 {
+                    break;
+                }
+            }
         }
     }
     out
@@ -701,19 +772,89 @@ fn bottom_n_mapped_mask(mapped_arr: &[f64], col_idxs: &[i64], col_lens: &[i64], 
             continue;
         }
         let col_start_idx = col_start_idxs[col];
-
-        // Collect (value, global_index) for this column
-        let mut items: Vec<(f64, usize)> = Vec::with_capacity(col_len);
-        for k in 0..col_len {
-            let global_idx = col_idxs[col_start_idx + k] as usize;
-            items.push((mapped_arr[global_idx], global_idx));
+        if n >= col_len {
+            for k in 0..col_len {
+                let global_idx = col_idxs[col_start_idx + k] as usize;
+                out[global_idx] = true;
+            }
+            continue;
+        }
+        if n == 0 {
+            continue;
         }
 
-        // Sort ascending; bottom N = first N after sort
-        items.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
-        let take = if col_len < n { col_len } else { n };
-        for k in 0..take {
-            out[items[k].1] = true;
+        // Collect non-NaN values for partitioning
+        let mut valid_values: Vec<f64> = Vec::with_capacity(col_len);
+        for k in 0..col_len {
+            let global_idx = col_idxs[col_start_idx + k] as usize;
+            let value = mapped_arr[global_idx];
+            if !value.is_nan() {
+                valid_values.push(value);
+            }
+        }
+
+        let n_valid = valid_values.len();
+        if n_valid == 0 {
+            let mut n_remaining = n;
+            for k in 0..col_len {
+                let global_idx = col_idxs[col_start_idx + k] as usize;
+                out[global_idx] = true;
+                n_remaining -= 1;
+                if n_remaining == 0 {
+                    break;
+                }
+            }
+            continue;
+        }
+
+        if n > n_valid {
+            for k in 0..col_len {
+                let global_idx = col_idxs[col_start_idx + k] as usize;
+                if !mapped_arr[global_idx].is_nan() {
+                    out[global_idx] = true;
+                }
+            }
+            let mut n_remaining = n - n_valid;
+            for k in 0..col_len {
+                let global_idx = col_idxs[col_start_idx + k] as usize;
+                if mapped_arr[global_idx].is_nan() {
+                    out[global_idx] = true;
+                    n_remaining -= 1;
+                    if n_remaining == 0 {
+                        break;
+                    }
+                }
+            }
+            continue;
+        }
+
+        valid_values.select_nth_unstable_by(n - 1, |a, b| a.partial_cmp(b).unwrap());
+        let pivot = valid_values[n - 1];
+
+        let mut n_less = 0usize;
+        for k in 0..col_len {
+            let global_idx = col_idxs[col_start_idx + k] as usize;
+            let value = mapped_arr[global_idx];
+            if !value.is_nan() && value < pivot {
+                out[global_idx] = true;
+                n_less += 1;
+            }
+        }
+
+        let mut n_remaining = n - n_less;
+        if n_remaining == 0 {
+            continue;
+        }
+        for k in 0..col_len {
+            let global_idx = col_idxs[col_start_idx + k] as usize;
+            let value = mapped_arr[global_idx];
+            if !value.is_nan() && value == pivot {
+                out[global_idx] = true;
+                n_remaining -= 1;
+                if n_remaining == 0 {
+                    break;
+                }
+            }
         }
     }
     out

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1802,10 +1802,41 @@ class TestRecordsRustParity:
             records_nb.mapped_to_mask_nb(mapped_arr, cm, records_nb.top_n_inout_map_nb, 2),
         )
 
+    def test_top_n_mapped_mask_nan(self):
+        mapped_arr = np.array([np.nan, np.nan, 12.0, 13.0, np.nan, 13.0, np.nan, np.nan, np.nan], dtype=np.float64)
+        col_arr = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2], dtype=np.int64)
+        cm = records_nb.col_map_nb(col_arr, 3)
+        np.testing.assert_array_equal(
+            records_dispatch.top_n_mapped_mask(mapped_arr, cm, 2, engine="rust"),
+            records_nb.mapped_to_mask_nb(mapped_arr, cm, records_nb.top_n_inout_map_nb, 2),
+        )
+
     def test_bottom_n_mapped_mask(self):
         mapped_arr = np.array([10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0], dtype=np.float64)
         col_arr = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2], dtype=np.int64)
         cm = records_nb.col_map_nb(col_arr, 3)
+        np.testing.assert_array_equal(
+            records_dispatch.bottom_n_mapped_mask(mapped_arr, cm, 2, engine="rust"),
+            records_nb.mapped_to_mask_nb(mapped_arr, cm, records_nb.bottom_n_inout_map_nb, 2),
+        )
+
+    def test_bottom_n_mapped_mask_nan(self):
+        mapped_arr = np.array([np.nan, np.nan, 12.0, 13.0, np.nan, 13.0, np.nan, np.nan, np.nan], dtype=np.float64)
+        col_arr = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2], dtype=np.int64)
+        cm = records_nb.col_map_nb(col_arr, 3)
+        np.testing.assert_array_equal(
+            records_dispatch.bottom_n_mapped_mask(mapped_arr, cm, 2, engine="rust"),
+            records_nb.mapped_to_mask_nb(mapped_arr, cm, records_nb.bottom_n_inout_map_nb, 2),
+        )
+
+    def test_top_bottom_n_mapped_mask_nan_overflow(self):
+        mapped_arr = np.array([np.nan, 1.0, np.nan, 2.0, np.nan, 3.0, np.nan, np.nan, 4.0], dtype=np.float64)
+        col_arr = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2], dtype=np.int64)
+        cm = records_nb.col_map_nb(col_arr, 3)
+        np.testing.assert_array_equal(
+            records_dispatch.top_n_mapped_mask(mapped_arr, cm, 2, engine="rust"),
+            records_nb.mapped_to_mask_nb(mapped_arr, cm, records_nb.top_n_inout_map_nb, 2),
+        )
         np.testing.assert_array_equal(
             records_dispatch.bottom_n_mapped_mask(mapped_arr, cm, 2, engine="rust"),
             records_nb.mapped_to_mask_nb(mapped_arr, cm, records_nb.bottom_n_inout_map_nb, 2),

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -186,6 +186,47 @@ class TestMappedArray:
             mapped_array.bottom_n_mask(0), np.array([False, False, False, False, False, False, False, False, False])
         )
 
+    def test_top_bottom_n_mask_with_nan(self):
+        mapped_array_with_nan = mapped_array.replace(
+            mapped_arr=np.array([10.0, np.nan, 12.0, 13.0, np.nan, 13.0, np.nan, np.nan, 10.0])
+        )
+        np.testing.assert_array_equal(
+            mapped_array_with_nan.top_n_mask(1, engine="numba"),
+            np.array([False, False, True, False, False, True, False, False, True]),
+        )
+        assert mapped_array_with_nan.top_n_mask(1, engine="numba").sum() == 3
+        np.testing.assert_array_equal(
+            mapped_array_with_nan.bottom_n_mask(2, engine="numba"),
+            np.array([True, False, True, True, False, True, True, False, True]),
+        )
+        assert mapped_array_with_nan.bottom_n_mask(2, engine="numba").sum() == 6
+
+    def test_top_bottom_n_mask_with_all_nan_column(self):
+        mapped_array_with_nan = mapped_array.replace(
+            mapped_arr=np.array([np.nan, np.nan, 12.0, 13.0, np.nan, 13.0, np.nan, np.nan, np.nan])
+        )
+        top_mask = mapped_array_with_nan.top_n_mask(2, engine="numba")
+        bottom_mask = mapped_array_with_nan.bottom_n_mask(2, engine="numba")
+        np.testing.assert_array_equal(
+            np.bincount(mapped_array_with_nan.col_arr[top_mask], minlength=3),
+            np.array([2, 2, 2]),
+        )
+        np.testing.assert_array_equal(
+            np.bincount(mapped_array_with_nan.col_arr[bottom_mask], minlength=3),
+            np.array([2, 2, 2]),
+        )
+
+    def test_top_bottom_n_mask_tie_order(self):
+        mapped_array_with_ties = mapped_array.replace(mapped_arr=np.array([1.0, 2.0, 2.0, 3.0, 3.0, 4.0, 5.0, 5.0, 5.0]))
+        np.testing.assert_array_equal(
+            mapped_array_with_ties.top_n_mask(2, engine="numba"),
+            np.array([False, True, True, False, True, True, False, True, True]),
+        )
+        np.testing.assert_array_equal(
+            mapped_array_with_ties.bottom_n_mask(2, engine="numba"),
+            np.array([True, True, False, True, True, False, True, True, False]),
+        )
+
     def test_top_n(self):
         np.testing.assert_array_equal(mapped_array.top_n(1).id_arr, np.array([2, 4, 6]))
         np.testing.assert_array_equal(mapped_array.top_n(0).id_arr, np.array([], dtype=np.int64))

--- a/vectorbt/records/nb.py
+++ b/vectorbt/records/nb.py
@@ -227,18 +227,53 @@ def top_n_inout_map_nb(inout: tp.Array1d, idxs: tp.Array1d, col: int, mapped_arr
     if n >= col_len:
         inout[idxs] = True
         return
-    n_partition = col_len - n
-    pivot = np.partition(mapped_arr, n_partition)[n_partition]
+
+    n_valid = 0
+    for i in range(col_len):
+        if mapped_arr[i] == mapped_arr[i]:
+            n_valid += 1
+
+    if n_valid == 0:
+        n_remaining = n
+        for i in range(col_len - 1, -1, -1):
+            inout[idxs[i]] = True
+            n_remaining -= 1
+            if n_remaining == 0:
+                break
+        return
+
+    valid_mapped_arr = np.empty(n_valid, dtype=mapped_arr.dtype)
+    j = 0
+    for i in range(col_len):
+        if mapped_arr[i] == mapped_arr[i]:
+            valid_mapped_arr[j] = mapped_arr[i]
+            j += 1
+
+    if n > n_valid:
+        for i in range(col_len):
+            if mapped_arr[i] == mapped_arr[i]:
+                inout[idxs[i]] = True
+        n_remaining = n - n_valid
+        for i in range(col_len - 1, -1, -1):
+            if mapped_arr[i] != mapped_arr[i]:
+                inout[idxs[i]] = True
+                n_remaining -= 1
+                if n_remaining == 0:
+                    break
+        return
+
+    n_partition = n_valid - n
+    pivot = np.partition(valid_mapped_arr, n_partition)[n_partition]
     n_greater = 0
     for i in range(col_len):
-        if mapped_arr[i] > pivot:
+        if mapped_arr[i] == mapped_arr[i] and mapped_arr[i] > pivot:
             n_greater += 1
             inout[idxs[i]] = True
     n_remaining = n - n_greater
     if n_remaining <= 0:
         return
     for i in range(col_len - 1, -1, -1):
-        if mapped_arr[i] == pivot:
+        if mapped_arr[i] == mapped_arr[i] and mapped_arr[i] == pivot:
             inout[idxs[i]] = True
             n_remaining -= 1
             if n_remaining == 0:
@@ -254,17 +289,52 @@ def bottom_n_inout_map_nb(inout: tp.Array1d, idxs: tp.Array1d, col: int, mapped_
     if n >= col_len:
         inout[idxs] = True
         return
-    pivot = np.partition(mapped_arr, n - 1)[n - 1]
+
+    n_valid = 0
+    for i in range(col_len):
+        if mapped_arr[i] == mapped_arr[i]:
+            n_valid += 1
+
+    if n_valid == 0:
+        n_remaining = n
+        for i in range(col_len):
+            inout[idxs[i]] = True
+            n_remaining -= 1
+            if n_remaining == 0:
+                break
+        return
+
+    valid_mapped_arr = np.empty(n_valid, dtype=mapped_arr.dtype)
+    j = 0
+    for i in range(col_len):
+        if mapped_arr[i] == mapped_arr[i]:
+            valid_mapped_arr[j] = mapped_arr[i]
+            j += 1
+
+    if n > n_valid:
+        for i in range(col_len):
+            if mapped_arr[i] == mapped_arr[i]:
+                inout[idxs[i]] = True
+        n_remaining = n - n_valid
+        for i in range(col_len):
+            if mapped_arr[i] != mapped_arr[i]:
+                inout[idxs[i]] = True
+                n_remaining -= 1
+                if n_remaining == 0:
+                    break
+        return
+
+    pivot = np.partition(valid_mapped_arr, n - 1)[n - 1]
     n_less = 0
     for i in range(col_len):
-        if mapped_arr[i] < pivot:
+        if mapped_arr[i] == mapped_arr[i] and mapped_arr[i] < pivot:
             n_less += 1
             inout[idxs[i]] = True
     n_remaining = n - n_less
     if n_remaining <= 0:
         return
     for i in range(col_len):
-        if mapped_arr[i] == pivot:
+        if mapped_arr[i] == mapped_arr[i] and mapped_arr[i] == pivot:
             inout[idxs[i]] = True
             n_remaining -= 1
             if n_remaining == 0:


### PR DESCRIPTION
## Summary
- make `top_n`/`bottom_n` NaN-aware in `records.nb` without dtype promotion, preserving deterministic tie order for non-NaN data
- align Rust `top_n_mapped_mask`/`bottom_n_mapped_mask` semantics with Numba for NaN-containing columns (including `n > n_valid` and all-NaN cases)
- add regression/parity coverage for NaN selection, overflow behavior, and tie-order determinism

## Backward compatibility
- non-NaN behavior is preserved; changes apply to NaN-containing inputs where selection is now explicit and engine-consistent

## Test plan
- [x] `uv run --python 3.11 --extra test pytest tests/test_records.py -k "top_bottom_n_mask_with_nan or top_bottom_n_mask_with_all_nan_column or top_bottom_n_mask_tie_order"`
- [x] `uv run --python 3.11 --extra test pytest tests/test_engine.py -k "top_n_mapped_mask_nan or bottom_n_mapped_mask_nan or top_bottom_n_mapped_mask_nan_overflow"` (Rust-gated tests skip when rust package is unavailable)
- [x] `uv run --python 3.11 --extra test pytest`


Co-authored by [Cursor](https://cursor.com)