### PR TITLE
Add FXMacroData data source

### DIFF
--- a/tests/test_fxmacrodata_data.py
+++ b/tests/test_fxmacrodata_data.py
@@ -1,0 +1,83 @@
+from unittest import mock
+
+import pandas as pd
+import pytest
+
+import vectorbt as vbt
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self.payload
+
+
+def test_fxmacrodata_download_symbol_fetches_close_only_ohlcv():
+    captured = {}
+
+    def fake_get(url, params, timeout, headers, **kwargs):
+        captured["url"] = url
+        captured["params"] = params
+        captured["timeout"] = timeout
+        captured["headers"] = headers
+        captured["kwargs"] = kwargs
+        return FakeResponse(
+            {
+                "data": [
+                    {"date": "2024-01-03", "val": 1.0920},
+                    {"date": "2024-01-01", "val": "1.1038"},
+                ]
+            }
+        )
+
+    with mock.patch("vectorbt.data.custom.requests.get", side_effect=fake_get):
+        actual = vbt.FXMacroData.download_symbol(
+            "eur/usd",
+            start="2024-01-01 UTC",
+            end="2024-01-31 UTC",
+            api_key="test-key",
+            timeout=12,
+        )
+
+    expected = pd.DataFrame(
+        {
+            "Open": [1.1038, 1.092],
+            "High": [1.1038, 1.092],
+            "Low": [1.1038, 1.092],
+            "Close": [1.1038, 1.092],
+            "Volume": [0.0, 0.0],
+        },
+        index=pd.DatetimeIndex(["2024-01-01", "2024-01-03"], tz="UTC", name="Datetime"),
+    )
+    pd.testing.assert_frame_equal(actual, expected)
+    assert captured == {
+        "url": "https://fxmacrodata.com/api/v1/forex/eur/usd",
+        "params": {
+            "start_date": "2024-01-01",
+            "end_date": "2024-01-31",
+            "api_key": "test-key",
+        },
+        "timeout": 12,
+        "headers": {"Accept": "application/json"},
+        "kwargs": {},
+    }
+
+
+def test_fxmacrodata_integrates_with_data_download():
+    def fake_get(url, params, timeout, headers, **kwargs):
+        return FakeResponse({"data": [{"date": "2024-01-01", "val": 1.1038}]})
+
+    with mock.patch("vectorbt.data.custom.requests.get", side_effect=fake_get):
+        data = vbt.FXMacroData.download("EURUSD", start="2024-01-01 UTC", end="2024-01-31 UTC")
+
+    assert data.get()["Close"].iloc[0] == 1.1038
+
+
+def test_fxmacrodata_rejects_invalid_pair_shape():
+    with pytest.raises(ValueError, match="EURUSD"):
+        vbt.FXMacroData.download_symbol("EUR", start="2024-01-01 UTC", end="2024-01-31 UTC")

--- a/vectorbt/data/__init__.py
+++ b/vectorbt/data/__init__.py
@@ -4,7 +4,7 @@
 """Modules for working with data sources."""
 
 from vectorbt.data.base import symbol_dict, Data
-from vectorbt.data.custom import SyntheticData, GBMData, YFData, BinanceData, CCXTData, AlpacaData
+from vectorbt.data.custom import SyntheticData, GBMData, YFData, FXMacroData, BinanceData, CCXTData, AlpacaData
 from vectorbt.data.updater import DataUpdater
 
 __all__ = [
@@ -14,6 +14,7 @@ __all__ = [
     "SyntheticData",
     "GBMData",
     "YFData",
+    "FXMacroData",
     "BinanceData",
     "CCXTData",
     "AlpacaData",

--- a/vectorbt/data/custom.py
+++ b/vectorbt/data/custom.py
@@ -5,10 +5,12 @@
 
 import time
 import warnings
+import os
 from functools import wraps
 
 import numpy as np
 import pandas as pd
+import requests
 from tqdm.auto import tqdm
 
 from vectorbt import _typing as tp
@@ -289,6 +291,136 @@ class YFData(Data):
         """Update the symbol.
 
         `**kwargs` will override keyword arguments passed to `YFData.download_symbol`."""
+        download_kwargs = self.select_symbol_kwargs(symbol, self.download_kwargs)
+        download_kwargs["start"] = self.data[symbol].index[-1]
+        kwargs = merge_dicts(download_kwargs, kwargs)
+        return self.download_symbol(symbol, **kwargs)
+
+
+class FXMacroData(Data):
+    """`Data` for daily FX reference rates coming from FXMacroData.
+
+    FXMacroData returns one daily spot/reference value per currency pair. This
+    class exposes those values as close-only OHLCV data by setting Open, High,
+    Low, and Close to the same value and Volume to 0.
+
+    Usage:
+        ```pycon
+        >>> import vectorbt as vbt
+
+        >>> fx_data = vbt.FXMacroData.download(
+        ...     "EURUSD",
+        ...     start="2024-01-01 UTC",
+        ...     end="2024-03-01 UTC",
+        ...     api_key="..."
+        ... )
+        >>> fx_data.get()
+                              Open    High     Low   Close  Volume
+        Datetime
+        2024-01-01 00:00:00+00:00  1.1038  1.1038  1.1038  1.1038     0.0
+        ```
+    """
+
+    @classmethod
+    def download_symbol(
+        cls,
+        symbol: str,
+        start: tp.DatetimeLike = "365 days ago UTC",
+        end: tp.DatetimeLike = "now UTC",
+        api_key: tp.Optional[str] = None,
+        base_url: str = "https://fxmacrodata.com/api/v1",
+        timeout: float = 30,
+        **kwargs,
+    ) -> tp.Frame:
+        """Download daily FX spot/reference rates from FXMacroData.
+
+        Args:
+            symbol (str): Six-letter FX pair such as "EURUSD", or separated
+                pair such as "EUR/USD".
+            start (any): Start datetime.
+
+                See `vectorbt.utils.datetime_.to_tzaware_datetime`.
+            end (any): End datetime.
+
+                See `vectorbt.utils.datetime_.to_tzaware_datetime`.
+            api_key (str): Optional FXMacroData API key. If omitted,
+                `FXMACRODATA_API_KEY` or `FXMD_API_KEY` will be used.
+            base_url (str): FXMacroData API base URL.
+            timeout (float): Request timeout in seconds.
+            **kwargs: Keyword arguments passed to `requests.get`.
+        """
+        base_currency, quote_currency = cls._split_pair(symbol)
+        start_ts = to_tzaware_datetime(start, tz=get_utc_tz()).date().isoformat()
+        end_ts = to_tzaware_datetime(end, tz=get_utc_tz()).date().isoformat()
+
+        params = {
+            "start_date": start_ts,
+            "end_date": end_ts,
+        }
+        api_key = api_key or os.getenv("FXMACRODATA_API_KEY") or os.getenv("FXMD_API_KEY")
+        if api_key:
+            params["api_key"] = api_key
+
+        url = "{}/forex/{}/{}".format(
+            base_url.rstrip("/"),
+            base_currency.lower(),
+            quote_currency.lower(),
+        )
+        response = requests.get(
+            url,
+            params=params,
+            timeout=timeout,
+            headers={"Accept": "application/json"},
+            **kwargs,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        rows = payload.get("data") if isinstance(payload, dict) else None
+        if not isinstance(rows, list):
+            raise ValueError("FXMacroData response did not include a data list")
+
+        records = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            date_value = row.get("date")
+            value = row.get("val")
+            if date_value is None or value is None:
+                continue
+            try:
+                dt = pd.Timestamp(date_value, tz=get_utc_tz())
+                price = float(value)
+            except (TypeError, ValueError):
+                continue
+            records.append(
+                {
+                    "Datetime": dt,
+                    "Open": price,
+                    "High": price,
+                    "Low": price,
+                    "Close": price,
+                    "Volume": 0.0,
+                }
+            )
+
+        if len(records) == 0:
+            raise ValueError(f"FXMacroData response did not include dated values for {symbol}")
+
+        df = pd.DataFrame.from_records(records)
+        df = df.sort_values("Datetime").set_index("Datetime")
+        return df[["Open", "High", "Low", "Close", "Volume"]]
+
+    @classmethod
+    def _split_pair(cls, symbol: str) -> tp.Tuple[str, str]:
+        normalized = "".join(char for char in str(symbol).upper() if char.isalpha())
+        if len(normalized) != 6:
+            raise ValueError("FXMacroData symbols must look like 'EURUSD' or 'EUR/USD'")
+        return normalized[:3], normalized[3:]
+
+    def update_symbol(self, symbol: str, **kwargs) -> tp.Frame:
+        """Update the symbol.
+
+        `**kwargs` will override keyword arguments passed to `FXMacroData.download_symbol`."""
         download_kwargs = self.select_symbol_kwargs(symbol, self.download_kwargs)
         download_kwargs["start"] = self.data[symbol].index[-1]
         kwargs = merge_dicts(download_kwargs, kwargs)


### PR DESCRIPTION
## Summary

Adds `FXMacroData`, a `vectorbt.data.base.Data` subclass for daily FX reference-rate data from FXMacroData.

The new data source:

- fetches `https://fxmacrodata.com/api/v1/forex/{base}/{quote}` with `start_date` and `end_date`
- accepts symbols such as `EURUSD` and `EUR/USD`
- supports API keys via `api_key`, `FXMACRODATA_API_KEY`, or `FXMD_API_KEY`
- converts FXMacroData daily spot/reference values into close-only OHLCV frames with `Volume = 0`
- supports normal `Data.download` and `update_symbol` workflows

FXMacroData provides daily official-source reference rates, so this is intended for daily FX/macro research rather than intraday exchange-traded candles.

## Validation

- `python -m pytest tests\test_fxmacrodata_data.py -q`
- `python -m compileall -q vectorbt\data\custom.py tests\test_fxmacrodata_data.py`
- `git diff --check`